### PR TITLE
Fix: Review rating always used the first one

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -51,7 +51,7 @@ function parseFields($) {
 		var userName = userInfo.text().trim();
 
 		var date = $(this).find('span[class=review-date]').text().trim();
-		var score = parseInt(filterScore($('.star-rating-non-editable-container').attr('aria-label').trim()));
+		var score = parseInt(filterScore($(this).find('.star-rating-non-editable-container').attr('aria-label').trim()));
 
 		var reviewContent = $(this).find('div[class=review-body]');
 		var title = reviewContent.find('span[class=review-title]').text().trim();


### PR DESCRIPTION
When scraping the review stars, instead of getting the rating corresponding to the current review,
it was obtaining the one from the first review on the list, which meant every single rating on the
list would get the first rating.