### PR TITLE
Add in-app purchase and ad-supported tags

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -37,6 +37,8 @@ function parseFields($) {
 
     var price = detailsInfo.find('meta[itemprop=price]').attr('content');
     var icon = detailsInfo.find('img.cover-image').attr('src');
+    var offersIAP = !!detailsInfo.find('.inapp-msg').length;
+    var adSupported = !!detailsInfo.find('.ads-supported-label-msg').length;
 
     var additionalInfo = $('.details-section-contents');
     var description = additionalInfo.find('div[itemprop=description] div');
@@ -81,6 +83,8 @@ function parseFields($) {
         icon: icon,
         minInstalls: minInstalls,
         maxInstalls: maxInstalls,
+        offersIAP: offersIAP,
+        adSupported: adSupported,
         score: score,
         reviews: reviews,
         histogram: histogram,


### PR DESCRIPTION
See attached screenshot.  This PR collects the tags that show the app's monetization scheme (in-app purchase or ads).  Google already tags apps that support in-app purchase. It now also requires developer to tag their apps as ad-supported if advertising is being used to monetize the app: http://www.engadget.com/2015/11/19/google-play-ad-supported-app-label/

![image](https://cloud.githubusercontent.com/assets/405975/12243823/3172f9e6-b8a9-11e5-8a1f-06b5818441db.png)
