### PR TITLE
Add developer email and website to the app

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -50,6 +50,8 @@ function parseFields($) {
     var installs = additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim();
     var minInstalls = cleanInt(installs.split(' - ')[0]);
     var maxInstalls = cleanInt(installs.split(' - ')[1]) || undefined;
+    var developerEmail = additionalInfo.find('.dev-link[href^="mailto:"]').attr('href').match(/^mailto:(.+)$/)[1].trim();
+    var developerWebsite = additionalInfo.find('.dev-link[href^="https://www.google"]').first().attr('href').match(/^https:\/\/www.google.com\/url\?q=([^&]+)/)[1].trim();
     var comments = [];
     $('.quoted-review').each(function(i){
       comments[i] = $(this).text().trim();
@@ -99,6 +101,8 @@ function parseFields($) {
         genre: genre,
         price: price,
         free: price === '0',
+        developerEmail: developerEmail,
+        developerWebsite: developerWebsite,
         video: video,
         comments: comments,
         screenshots: screenshots


### PR DESCRIPTION
Bring in the app developer's email and website as scraped from the links at the bottom of the page. If would like, we could add an optional `options` object to the app scraping function where one could pass in which fields it ones to be scraped or not.

![image](https://cloud.githubusercontent.com/assets/405975/12265412/8ff08aaa-b945-11e5-92f3-553dd414e51f.png)
