### PR TITLE
Safe guard the code in case of no developer email/website info

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -52,9 +52,9 @@ function parseFields($) {
     var maxInstalls = cleanInt(installs.split(' - ')[1]) || undefined;
 
     var developerEmail = (additionalInfo.find('.dev-link[href^="mailto:"]').attr('href') || '').match(/^mailto:(.+)$/);
-    developerEmail = developerEmail ? developerEmail[1].trim() : null;
+    developerEmail = developerEmail ? developerEmail[1].trim() : undefined;
     var developerWebsite = (additionalInfo.find('.dev-link[href^="https://www.google"]').first().attr('href') || '').match(/^https:\/\/www.google.com\/url\?q=([^&]+)/)[1].trim();
-    developerWebsite = developerWebsite ? developerWebsite[1].trim() : null;
+    developerWebsite = developerWebsite ? developerWebsite[1].trim() : undefined;
 
     var comments = [];
     $('.quoted-review').each(function(i){
@@ -84,36 +84,33 @@ function parseFields($) {
         screenshots[i] = $(elem).attr('src');
     });
 
-    var app = {
-      title                 : title,
-      icon                  : icon,
-      minInstalls           : minInstalls,
-      maxInstalls           : maxInstalls,
-      offersIAP             : offersIAP,
-      adSupported           : adSupported,
-      score                 : score,
-      reviews               : reviews,
-      histogram             : histogram,
-      description           : description.text(),
-      descriptionHTML       : description.html(),
-      developer             : developer,
-      updated               : updated,
-      version               : version,
-      size                  : size,
-      requiredAndroidVersion: requiredAndroidVersion,
-      contentRating         : contentRating,
-      genre                 : genre,
-      price                 : price,
-      free                  : price === '0',
-      video                 : video,
-      comments              : comments,
-      screenshots           : screenshots
+    return {
+        title: title,
+        icon: icon,
+        minInstalls: minInstalls,
+        maxInstalls: maxInstalls,
+        offersIAP: offersIAP,
+        adSupported: adSupported,
+        score: score,
+        reviews: reviews,
+        histogram: histogram,
+        description: description.text(),
+        descriptionHTML: description.html(),
+        developer: developer,
+        updated: updated,
+        version: version,
+        size: size,
+        requiredAndroidVersion: requiredAndroidVersion,
+        contentRating: contentRating,
+        genre: genre,
+        price: price,
+        free: price === '0',
+        developerEmail: developerEmail,
+        developerWebsite: developerWebsite,
+        video: video,
+        comments: comments,
+        screenshots: screenshots
     };
-
-    if (developerEmail) app.developerEmail = developerEmail;
-    if (developerWebsite) app.developerWebsite = developerWebsite;
-
-    return app;
 }
 
 function cleanInt(number) {

--- a/lib/app.js
+++ b/lib/app.js
@@ -50,8 +50,12 @@ function parseFields($) {
     var installs = additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim();
     var minInstalls = cleanInt(installs.split(' - ')[0]);
     var maxInstalls = cleanInt(installs.split(' - ')[1]) || undefined;
-    var developerEmail = additionalInfo.find('.dev-link[href^="mailto:"]').attr('href').match(/^mailto:(.+)$/)[1].trim();
-    var developerWebsite = additionalInfo.find('.dev-link[href^="https://www.google"]').first().attr('href').match(/^https:\/\/www.google.com\/url\?q=([^&]+)/)[1].trim();
+
+    var developerEmail = (additionalInfo.find('.dev-link[href^="mailto:"]').attr('href') || '').match(/^mailto:(.+)$/);
+    developerEmail = developerEmail ? developerEmail[1].trim() : null;
+    var developerWebsite = (additionalInfo.find('.dev-link[href^="https://www.google"]').first().attr('href') || '').match(/^https:\/\/www.google.com\/url\?q=([^&]+)/)[1].trim();
+    developerWebsite = developerWebsite ? developerWebsite[1].trim() : null;
+
     var comments = [];
     $('.quoted-review').each(function(i){
       comments[i] = $(this).text().trim();
@@ -80,33 +84,36 @@ function parseFields($) {
         screenshots[i] = $(elem).attr('src');
     });
 
-    return {
-        title: title,
-        icon: icon,
-        minInstalls: minInstalls,
-        maxInstalls: maxInstalls,
-        offersIAP: offersIAP,
-        adSupported: adSupported,
-        score: score,
-        reviews: reviews,
-        histogram: histogram,
-        description: description.text(),
-        descriptionHTML: description.html(),
-        developer: developer,
-        updated: updated,
-        version: version,
-        size: size,
-        requiredAndroidVersion: requiredAndroidVersion,
-        contentRating: contentRating,
-        genre: genre,
-        price: price,
-        free: price === '0',
-        developerEmail: developerEmail,
-        developerWebsite: developerWebsite,
-        video: video,
-        comments: comments,
-        screenshots: screenshots
+    var app = {
+      title                 : title,
+      icon                  : icon,
+      minInstalls           : minInstalls,
+      maxInstalls           : maxInstalls,
+      offersIAP             : offersIAP,
+      adSupported           : adSupported,
+      score                 : score,
+      reviews               : reviews,
+      histogram             : histogram,
+      description           : description.text(),
+      descriptionHTML       : description.html(),
+      developer             : developer,
+      updated               : updated,
+      version               : version,
+      size                  : size,
+      requiredAndroidVersion: requiredAndroidVersion,
+      contentRating         : contentRating,
+      genre                 : genre,
+      price                 : price,
+      free                  : price === '0',
+      video                 : video,
+      comments              : comments,
+      screenshots           : screenshots
     };
+
+    if (developerEmail) app.developerEmail = developerEmail;
+    if (developerWebsite) app.developerWebsite = developerWebsite;
+
+    return app;
 }
 
 function cleanInt(number) {


### PR DESCRIPTION
I discovered that my previous PR #61 could crash the code in case the developer email or website info was missing from the page.  This patch protects from that by checking for nulls.