### PR TITLE
[Bugfix] Exception when developer email or website missing

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -50,8 +50,17 @@ function parseFields($) {
     var installs = additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim();
     var minInstalls = cleanInt(installs.split(' - ')[0]);
     var maxInstalls = cleanInt(installs.split(' - ')[1]) || undefined;
-    var developerEmail = additionalInfo.find('.dev-link[href^="mailto:"]').attr('href').match(/^mailto:(.+)$/)[1].trim();
-    var developerWebsite = additionalInfo.find('.dev-link[href^="https://www.google"]').first().attr('href').match(/^https:\/\/www.google.com\/url\?q=([^&]+)/)[1].trim();
+
+    var developerEmail = additionalInfo.find('.dev-link[href^="mailto:"]').first().attr('href');
+    if (developerEmail) {
+        developerEmail = developerEmail.match(/^mailto:(.+)$/)[1].trim();
+    }
+    
+    var developerWebsite = additionalInfo.find('.dev-link[href^="https://www.google"]').first().attr('href');
+    if (developerWebsite) {
+        developerWebsite = developerWebsite.match(/^https:\/\/www.google.com\/url\?q=([^&]+)/)[1].trim();
+    }
+
     var comments = [];
     $('.quoted-review').each(function(i){
       comments[i] = $(this).text().trim();


### PR DESCRIPTION
For me the `.match(...)` calls crashed on some apps, where no developer email or website was present.