### PR TITLE
fix post /store/getreviews since it was returning 400

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -23,7 +23,8 @@ function reviews(opts) {
 				id: opts.appId || opts.id,
 				reviewSortOrder: sort,
 				hl: opts.lang || 'en',
-				reviewType: 0
+				reviewType: 0,
+				xhr: 1
 			},
 			json: true
 		};


### PR DESCRIPTION
The reviews method was returning a 400 status code with a "Not found" message. I inspected the request made by the PlayStore using the browser and found out it was missing a parameter in the POST body. I added it and the request seems to work fine again.