### PR TITLE
Fixing reviews title and text parsing

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -53,7 +53,7 @@ function parseFields($) {
 		var date = $(this).find('span[class=review-date]').text().trim();
 		var score = parseInt(filterScore($(this).find('.star-rating-non-editable-container').attr('aria-label').trim()));
 
-		var reviewContent = $(this).find('div[class=review-body]');
+		var reviewContent = $(this).find('.review-body');
 		var title = reviewContent.find('span[class=review-title]').text().trim();
 		var text = filterReviewText(reviewContent.text().trim(), title.length);
 


### PR DESCRIPTION
Google apparently inserted a new class to the "review-body" div. 

Now its 
```html
<div class="review-body with-review-wrapper">...
``` 

So the current find criteria `div[class=review-body]` wasn't able to find the div, and the review's title and text were not showing up.

I changed it to a broader criteria `.review-body` so now it's working again