### PR TITLE
Fix issue with French number of installs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -66,7 +66,15 @@ function parseFields ($) {
   const requiredAndroidVersion = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
   const contentRating = additionalInfo.find('div.content[itemprop="contentRating"]').text().trim();
   const size = additionalInfo.find('div.content[itemprop="fileSize"]').text().trim();
-  const installs = additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim().split(' - ');
+  
+  const downloads = additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim();
+  let installs = downloads.split(' - ');
+
+  // French
+  if (installs.length < 2) {
+    installs = downloads.split(' et ');
+  }
+
   const minInstalls = cleanInt(installs[0]);
   const maxInstalls = cleanInt(installs[1]) || undefined;
 

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -63,4 +63,12 @@ describe('App method', () => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&hl=es&gl=ar');
       });
   });
+
+  it('should find right install numbers in French', () => {
+    return gplay.app({appId: 'com.dxco.pandavszombies', lang: 'fr', country: 'fr'})
+      .then((app) => {
+        assert.isNumber(app.minInstalls);
+        assert.isNumber(app.maxInstalls);
+      });
+  });
 });


### PR DESCRIPTION
I found a problem on minInstalls and maxInstalls number in French: the separator for the two values is not a hyphen but a word ("et" for between ... "and" ...). See https://play.google.com/store/apps/details?id=com.airbnb.android&hl=de&gl=fr.

This fix the issue for French, but I think it's worth trying to find other languages where the problem could exist.