### PR TITLE
Fix reviews' sort

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -67,7 +67,7 @@ module.exports.collection = {
 module.exports.sort = {
   NEWEST: 0,
   RATING: 1,
-  HELPFULNESS: 4
+  HELPFULNESS: 2
 };
 
 module.exports.age = {

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -11,15 +11,13 @@ function reviews (opts) {
   return new Promise(function (resolve, reject) {
     validate(opts);
 
-    const sort = convertSort(opts.sort);
-
     const options = {
       method: 'POST',
       uri: 'https://play.google.com/store/getreviews',
       form: {
         pageNum: opts.page || 0,
         id: opts.appId || opts.id,
-        reviewSortOrder: sort,
+        reviewSortOrder: opts.sort,
         hl: opts.lang || 'en',
         reviewType: 0,
         xhr: 1
@@ -92,19 +90,6 @@ function validate (opts) {
   }
   if (opts.page && opts.page < 0) {
     throw new Error('Page cannot be lower than 0');
-  }
-}
-
-function convertSort (sort) {
-  switch (sort) {
-    case 'newest':
-      return 0;
-    case 'rating':
-      return 1;
-    case 'helpfulness':
-      return 4;
-    default:
-      return 0;
   }
 }
 


### PR DESCRIPTION
Current Google Play reviews' constant HELPFULNESS is `2` and not `4` so I fixed.
Also `convertSort` in `reviews.js` was redundant and buggy since it was forcing the sort option to be always `NEWEST`