### PR TITLE
Normalize Android required version (only version or VARY)

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -63,7 +63,8 @@ function parseFields ($) {
   const description = additionalInfo.find('div[itemprop=description] div');
   const version = additionalInfo.find('div.content[itemprop="softwareVersion"]').text().trim();
   const updated = additionalInfo.find('div.content[itemprop="datePublished"]').text().trim();
-  const requiredAndroidVersion = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
+  const androidVersionText = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
+  const androidVersion = normalizeAndroidVersion(androidVersionText);
   const contentRating = additionalInfo.find('div.content[itemprop="contentRating"]').text().trim();
   const size = additionalInfo.find('div.content[itemprop="fileSize"]').text().trim();
   const installs = installNumbers(additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim());
@@ -131,7 +132,8 @@ function parseFields ($) {
     histogram,
     offersIAP,
     adSupported,
-    requiredAndroidVersion,
+    androidVersionText,
+    androidVersion,
     contentRating,
     screenshots,
     video,
@@ -170,6 +172,16 @@ function installNumbers(downloads) {
   if (installs.length == 2) return installs;
 
   throw new Error('Unable to parse min/max downloads');
+}
+
+function normalizeAndroidVersion(androidVersionText) {
+  let matches = androidVersionText.match(/^([0-9\.]+)[^0-9\.].+/);
+
+  if (!matches || typeof matches[1] === 'undefined') {
+    return 'VARY';
+  }
+
+  return matches[1];
 }
 
 module.exports = memoize(app);

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -31,7 +31,7 @@ describe('App method', () => {
 
         assert.isString(app.version);
         assert.isString(app.size);
-        assert.isString(app.requiredAndroidVersion);
+        assert.isString(app.androidVersion);
         assert.isString(app.contentRating);
 
         assert.equal(app.price, '0');
@@ -104,6 +104,7 @@ describe('App method', () => {
     ['vi']
   ];
 
+  // Facebook
   for (let i in languages) {
     let lang = languages[i][0];
     let country = typeof languages[i][1] !== 'undefined' ? languages[i][1] : lang;
@@ -132,13 +133,72 @@ describe('App method', () => {
 
           assert.isString(app.version);
           assert.isString(app.size);
-          assert.isString(app.requiredAndroidVersion);
+          assert.equal(app.androidVersion, 'VARY');
+          assert.isString(app.androidVersionText);
           assert.isString(app.contentRating);
 
           assert.equal(app.price, '0');
           assert(app.free);
 
           assert.equal(app.developer, 'Facebook');
+          assertValidUrl(app.developerWebsite);
+          assert(validator.isEmail(app.developerEmail), `${app.developerEmail} is not an email`);
+
+          if (app.video) {
+            assertValidUrl(app.video);
+          }
+
+          ['1', '2', '3', '4', '5'].map((v) => assert.property(app.histogram, v));
+
+          assert(app.screenshots.length);
+          app.screenshots.map(assertValidUrl);
+
+          assert(app.comments.length);
+          app.comments.map(assert.isString);
+
+          assert(app.recentChanges.length);
+          app.recentChanges.map(assert.isString);
+        });
+    });
+  }
+
+  // What's App
+  for (let i in languages) {
+    let lang = languages[i][0];
+    let country = typeof languages[i][1] !== 'undefined' ? languages[i][1] : lang;
+
+    it('should fetch valid application data in '+lang+'_'+country, () => {
+      return gplay.app({appId: 'com.whatsapp', lang: lang, country: country})
+        .then((app) => {
+          assert.equal(app.appId, 'com.whatsapp');
+          assert.equal(app.title, 'WhatsApp Messenger');
+          assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.whatsapp&hl='+lang+'&gl='+country);
+          assertValidUrl(app.icon);
+
+          assert.isNumber(app.score);
+          assert(app.score > 0);
+          assert(app.score <= 5);
+
+          assert.isNumber(app.minInstalls);
+          assert.isNumber(app.maxInstalls);
+          assert.isNumber(app.reviews);
+
+          assert.isString(app.summary);
+          assert.isString(app.description);
+          assert.isString(app.descriptionHTML);
+          assert.isString(app.updated);
+          assert.equal(app.genreId, 'COMMUNICATION');
+
+          assert.isString(app.version);
+          assert.isString(app.size);
+          assert.equal(app.androidVersion, '2.1');
+          assert.isString(app.androidVersionText);
+          assert.isString(app.contentRating);
+
+          assert.equal(app.price, '0');
+          assert(app.free);
+
+          assert.equal(app.developer, 'WhatsApp Inc.');
           assertValidUrl(app.developerWebsite);
           assert(validator.isEmail(app.developerEmail), `${app.developerEmail} is not an email`);
 

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -86,7 +86,8 @@ describe('List method', () => {
 
       assert.isString(app.version);
       assert.isString(app.size);
-      assert.isString(app.requiredAndroidVersion);
+      assert.isString(app.androidVersionText);
+      assert.isString(app.androidVersion);
       assert.isString(app.contentRating);
 
       assert.equal(app.price, '0');


### PR DESCRIPTION
This PR normalizes the returned Android version to avoid having to deal with localized strings.

I checked manually and the format of versions is the same for every language (at least every language in the list I put in the tests): `<version> <localized string>` (here is the list for Android 2.1 as a gist: https://gist.github.com/tgalopin/21d6ba9fc8802b3286eb4716b03dad30).

I added tests for What's App in order to tests this behavior (Facebook is for VARY).