### PR TITLE
Detect reviews's score in Japanese

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -109,7 +109,7 @@ function filterScore (score, lang) {
   let regex;
   if (lang === 'ja') {
     // japanese reviews: '5つ星のうち3つ星で評価しました'
-    regex = /5つ星のうち([0-5]{1})つ星で評価しました/;
+    regex = /[0-5].*?([0-5]{1})/;
   } else {
     // default: 'Rated 3 stars out of five stars'
     regex = /([0-5]{1})/;

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -31,13 +31,13 @@ function reviews (opts) {
         return response[0][2];
       })
       .then(cheerio.load)
-      .then(parseFields)
+      .then($ => parseFields($, opts))
       .then(resolve)
       .catch(reject);
   });
 }
 
-function parseFields ($) {
+function parseFields ($, opts) {
   const result = [];
 
   const reviewsContainer = $('div[class=single-review]');
@@ -48,7 +48,7 @@ function parseFields ($) {
     const userName = userInfo.text().trim();
 
     const date = $(this).find('span[class=review-date]').text().trim();
-    const score = parseInt(filterScore($(this).find('.star-rating-non-editable-container').attr('aria-label').trim()));
+    const score = parseInt(filterScore($(this).find('.star-rating-non-editable-container').attr('aria-label').trim(), opts.lang));
     const url = 'https://play.google.com' + info.find('.reviews-permalink').attr('href');
 
     const reviewContent = $(this).find('.review-body');
@@ -105,9 +105,9 @@ function filterUserId (userId) {
   return result[1];
 }
 
-function filterScore (score) {
+function filterScore (score, lang) {
   let regex;
-  if (score.indexOf('5つ星のうち') !== -1) {
+  if (lang === 'ja') {
     // japanese reviews: '5つ星のうち3つ星で評価しました'
     regex = /5つ星のうち([0-5]{1})つ星で評価しました/;
   } else {

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -106,7 +106,14 @@ function filterUserId (userId) {
 }
 
 function filterScore (score) {
-  const regex = /([0-5]{1})/;
+  let regex;
+  if (score.indexOf('5つ星のうち') !== -1) {
+    // japanese reviews: '5つ星のうち3つ星で評価しました'
+    regex = /5つ星のうち([0-5]{1})つ星で評価しました/;
+  } else {
+    // default: 'Rated 3 stars out of five stars'
+    regex = /([0-5]{1})/;
+  }
   const result = score.match(regex);
   return result[1];
 }

--- a/test/lib.reviews.js
+++ b/test/lib.reviews.js
@@ -23,6 +23,12 @@ describe('Reviews method', () => {
       reviews.map(assertValid);
     });
   });
+  it('should retrieve the reviews of an app in Japanese', () => {
+    return gplay.reviews({appId: 'com.dxco.pandavszombies', lang: 'ja'})
+    .then((reviews) => {
+      reviews.map(assertValid);
+    });
+  });
 
   it('should validate the sort', () => {
     return gplay.reviews({


### PR DESCRIPTION
When fetching reviews for the Japanese language, score text has this format `5つ星のうち3つ星で評価しました`, in contrast to the default english format `Rated 3 stars out of five stars`.

Uber in English: https://play.google.com/store/apps/details?id=com.ubercab&hl=en
Uber in Japanese: https://play.google.com/store/apps/details?id=com.ubercab&hl=ja

Maybe a cleaner option would be add a `country` option as in `app`. However I didn't check if that's possible for `reviews`' api. Also I tried to make the less changes possible
