### PR TITLE
Scrape the application title correctly regardless of User Agent.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -39,7 +39,7 @@ function app (opts) {
 
 function parseFields ($) {
   const detailsInfo = $('.details-info');
-  const title = detailsInfo.find('div.document-title').text().trim();
+  const title = detailsInfo.find('.document-title').text().trim();
   const developer = detailsInfo.find('span[itemprop="name"]').text();
   const summary = $('meta[name="description"]').attr('content');
 


### PR DESCRIPTION
**Context**
The type of the element node holding the application title can either be a `div` or a `h1` depending on the User Agent header set when making the request. This means that the title of the application is not collected in some circumstances.

**What's this do?**
Changes the selector to not include the element type. This correctly selects the application title in all circumstances.