### PR TITLE
Upgrade to latest `request` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "debug": "^2.2.0",
     "memoizee": "^0.3.10",
     "ramda": "^0.21.0",
-    "request": "^2.72.0",
+    "request": "^2.79.0",
     "throttled-request": "^0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The latest request changes to using `uuid` instead of `node-uuid` (now abandoned). The old `node-uuid` would log warnings when testing with automocking under `jest`. This change makes `google-play-scraper` less noisy under `jest`.