### PR TITLE
Add query-string to package.json

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -3,7 +3,7 @@
 const request = require('./utils/request');
 const memoize = require('./utils/memoize');
 const cheerio = require('cheerio');
-const queryString = require('querystring');
+const queryString = require('query-string');
 const url = require('url');
 const R = require('ramda');
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "memoizee": "^0.3.10",
     "ramda": "^0.21.0",
     "request": "^2.79.0",
-    "throttled-request": "^0.1.1"
+    "throttled-request": "^0.1.1",
+    "query-string": "4.3.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
I was developing in React Native, and ran across and error message saying that couldn't find the querystring module. I looked through your package.json, and didn't see the package. 
I didn't know if you used 
[query-string](https://www.npmjs.com/package/query-string)
or
[querystring](https://www.npmjs.com/package/querystring)

but I saw documentation for query-string, and stringify. So I assumed that was the one. If its the other, I can certainly change it.

Cheers.

