### PR TITLE
Cache clp and detect it from either tag or script on page

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -6,7 +6,13 @@ const cheerio = require('cheerio');
 const getParseList = require('./utils/parseList');
 
 function getClp (html) {
-  return html.match(/\?clp=(.*?)">/)[1].replace(/%3D/g, '=');
+  // Try to find clp from "next page" html elem.
+  let match = html.match(/\?clp=(.*?)">/);
+  // ... if we don't have it, we're probably on innerPage;
+  // try to parse it from search_collection_more_results_cluster instead
+  // var curl='https://play.google.com/store/apps/collection/search_collection_more_results_cluster?clp\x3dggENCgVwYW5kYRABGgIIAA%3D%3D:S:ANO1ljKV8KM';
+  if (!match) match = html.match(/\?clp\\x3d(.*?)';/);
+  return match && match[1].replace(/%3D/g, '=');
 }
 
 function getNextToken (html) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -24,9 +24,9 @@ function getNextToken (html) {
  * Extract navigation tokens for next pages, parse results and call
  * `checkFinished` to repeat the process with next page if necessary.
  */
-function processAndRecur (html, opts, savedApps) {
+function processAndRecur (html, opts, savedApps, clp) {
   const nextToken = getNextToken(html);
-  const clp = getClp(html); // TODO this doesn't change could be calculated just once
+  clp = clp || getClp(html);
 
   const $ = cheerio.load(html);
   return getParseList(opts)($)
@@ -60,7 +60,7 @@ function checkFinished (opts, savedApps, nextToken, clp) {
   };
 
   return request(requestOptions, opts.throttle)
-    .then((html) => processAndRecur(html, opts, savedApps));
+    .then((html) => processAndRecur(html, opts, savedApps, clp));
 }
 
 /*

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -29,4 +29,11 @@ describe('Search method', () => {
        assert(apps.length === 155, 'should return as many apps as requested');
        assert(R.uniq(apps).length === 155, 'should return distinct apps');
      }));
+
+  it('should fetch multiple pages of when not starting from cluster of subsections', () =>
+     gplay.search({term: 'clash of clans', num: 65})
+     .then((apps) => {
+       assert(apps.length === 65, 'should return as many apps as requested');
+       assert(R.uniq(apps).length === 65, 'should return distinct apps');
+     }));
 });


### PR DESCRIPTION
Our tests started to fail this morning; reason is that nowadays it seems that only initial page loaded has clp token (whatever that is).
So this fixes a TODO and extracts clp only after initial request.

ALSO _sometimes_ clp can't be found out from html anymore, but is present in script part (`var curl = '...blablab..?clp\x3d`); fixed that as well and added a test case for it.
