### PR TITLE
Add developerId field

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Results:
   reviews: 2312,
   histogram: { '1': 12, '2': 7, '3': 16, '4': 40, '5': 231 },
   description: 'Everyone in town has gone zombie.',
+  developerId: "DxCo+Games",
   descriptionHTML: 'Everyone in town has gone <b>zombie</b>.',
   developer: 'DxCo Games',
   developerEmail: 'dxcogames@gmail.com',
@@ -109,6 +110,7 @@ Results:
     appId: 'com.playappking.busrush',
     summary: 'Bus Rush is an amazing running game for Android! Start running now!',
     developer: 'Play App King',
+    developerId: '6375024885749937863',
     title: 'Bus Rush',
     icon: 'https://lh3.googleusercontent.com/R6hmyJ6ls6wskk5hHFoW02yEyJpSG36il4JBkVf-Aojb1q4ZJ9nrGsx6lwsRtnTqfA=w340',
     score: 3.9,
@@ -119,6 +121,7 @@ Results:
     title: 'Crossy Road',
     summary: 'Embark on an action arcade, endless runner journey!',
     developer: 'Yodo1 Games',
+    developerId: 'Yodo1+Games',
     icon: 'https://lh3.googleusercontent.com/doHqbSPNekdR694M-4rAu9P2B3V6ivff76fqItheZGJiN4NBw6TrxhIxCEpqgO3jKVg=w340',
     score: 4.5,
     price: '0',
@@ -157,6 +160,7 @@ Results:
     summary: 'An exciting action adventure RPG of Panda proportions!',
     title: 'Taichi Panda',
     developer: 'Snail Games USA',
+    developerId: 'Snail+Games+USA+Inc',
     icon: 'https://lh3.googleusercontent.com/g8RMjpRk9yetsui4g5lxnioAFwtgoKUJDBnb2knJMrOaLOtHrwU1qYkb-PadbL0Zmg=w340',
     score: 4.1,
     price: '0',
@@ -166,6 +170,7 @@ Results:
     summary: 'Plan your every pop to rescue baby pandas from the evil Baboon!',
     title: 'Panda Pop',
     developer: 'SGN',
+    developerId: '5509190841173705883',
     icon: 'https://lh5.ggpht.com/uAAUBzEHtD_-mTxomL2wFxb5VSdtNllk9M4wjVdTGMD8pH79RtWGYQYrrtfVTjq7PV7M=w340',
     score: 4.2,
     price: '0',
@@ -175,7 +180,7 @@ Results:
 ### developer
 Returns the list of applications by the given developer name. Options:
 
-* `devId`: the name of the developer.
+* `dev`: the name of the developer.
 * `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the app list.
 * `country` (optional, defaults to `'us'`): the two letter country code used to retrieve the applications. Needed when the app is available only in some countries.
 * `num` (optional, defaults to 20): the amount of apps to retrieve.
@@ -196,6 +201,7 @@ Results:
     title: 'Panda vs Zombie 2 Panda\'s back',
     summary: 'Help Rocky the Panda warrior to fight zombies again!',
     developer: 'DxCo Games',
+    developerId: 'DxCo+Games',
     icon: 'https://lh3.googleusercontent.com/kFco0LtC7ICP0QrtpkF-QQahU-iwuDgEsH0AClQcHwtzsO5-8BGTf8QgR6dlCLxqBLc=w340',
     score: 3.9,
     price: '0',
@@ -205,6 +211,7 @@ Results:
     title: 'Panda vs Zombie: panda ftw',
     summary: 'Help Rocky the Panda warrior to fight zombie games and save the Panda kind.',
     developer: 'DxCo Games',
+    developerId: 'DxCo+Games',
     icon: 'https://lh6.ggpht.com/5mI27oolnooL__S3ns9qAf_6TsFNExMtUAwTKz6prWCxEmVkmZZZwe3lI-ZLbMawEJh3=w340',
     score: 4.5,
     price: '0',
@@ -299,6 +306,7 @@ Results:
     appId: 'com.creative.rambo',
     summary: 'Rambo - The Mobile Game',
     developer: 'Creative Distribution Ltd',
+    developerId: '8812103738509382093',
     icon: '//lh3.googleusercontent.com/QDRAv7v4LSCfZgz3GIbOSz8Zj8rWqeeYuqqYiqyQXkxRJwG7vvUltzsFaWK5D7-JMnIZ=w340',
     score: 3.3,
     price: '$2.16',

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Results:
 ### developer
 Returns the list of applications by the given developer name. Options:
 
-* `dev`: the name of the developer.
+* `devId`: the name of the developer.
 * `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the app list.
 * `country` (optional, defaults to `'us'`): the two letter country code used to retrieve the applications. Needed when the app is available only in some countries.
 * `num` (optional, defaults to 20): the amount of apps to retrieve.

--- a/lib/app.js
+++ b/lib/app.js
@@ -46,6 +46,7 @@ function parseFields ($) {
   const detailsInfo = $('.details-info');
   const title = detailsInfo.find('.document-title').text().trim();
   const developer = detailsInfo.find('span[itemprop="name"]').text();
+  const developerId = detailsInfo.find('.primary').attr('href').split('id=')[1];
   const summary = $('meta[name="description"]').attr('content');
 
   const mainGenre = detailsInfo.find('.category').first();
@@ -127,6 +128,7 @@ function parseFields ($) {
     score,
     reviews,
     developer,
+    developerId,
     developerEmail,
     developerWebsite,
     updated,

--- a/lib/utils/parseList.js
+++ b/lib/utils/parseList.js
@@ -61,6 +61,7 @@ function parseApp (app) {
     title: app.find('a.title').attr('title'),
     summary: app.find('div.description').text().trim(),
     developer: app.find('a.subtitle').text(),
+    developerId: app.find('a.subtitle').attr('href').split('id=')[1],
     icon: app.find('img.cover-image').attr('data-cover-large'),
     score: score,
     price: price,

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -43,6 +43,7 @@ describe('App method', () => {
         assert(app.preregister === false);
 
         assert.equal(app.developer, 'DxCo Games');
+        assert.equal(app.developerId, 'DxCo+Games');
         assertValidUrl(app.developerWebsite);
         assert(validator.isEmail(app.developerEmail), `${app.developerEmail} is not an email`);
 

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -94,6 +94,7 @@ describe('List method', () => {
       assert(app.free);
 
       assert.isString(app.developer);
+      assert.isString(app.developerId);
       if (app.developerWebsite) {
         assertValidUrl(app.developerWebsite);
       }


### PR DESCRIPTION
This pr aims to add the field 'developerId' to the apps retrieved, since it can be a util field and was requested in [#153](https://github.com/facundoolano/google-play-scraper/issues/153).

All the methods, docs and tests were update. 

It's worth to mention the change in the `developer` method api. I've decided to replace the `devId` option for `dev` (whereas it's the developer name, and not its id). It was also necessary because Google Play seems to use different urls and id patterns for developers (See below), and each one only works with one kind of id, so I decided to touch in the way that request are being made right now.

[https://play.google.com/store/apps/dev?id=5509190841173705883](https://play.google.com/store/apps/dev?id=5509190841173705883)

and

[https://play.google.com/store/apps/developer?id=DxCo+Games](https://play.google.com/store/apps/developer?id=DxCo+Games)
