### PR TITLE
Fix the error in list method when passing start greater than 199

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -14,6 +14,8 @@ function list (opts) {
 
     const options = {
       url: buildUrl(opts),
+      method: 'POST',
+      form: opts.form,
       proxy: opts.proxy
     };
 
@@ -51,6 +53,7 @@ function validate (opts) {
 
   opts.lang = opts.lang || 'en';
   opts.country = opts.country || 'us';
+  opts.form = {start: opts.start};
 }
 
 function buildUrl (opts) {
@@ -61,7 +64,7 @@ function buildUrl (opts) {
   }
 
   url += `/collection/${opts.collection}`;
-  url += `?hl=${opts.lang}&gl=${opts.country}&start=${opts.start}&num=${opts.num}`;
+  url += `?hl=${opts.lang}&gl=${opts.country}&num=${opts.num}`;
 
   if (opts.age) {
     url += `&age=${opts.age}`;


### PR DESCRIPTION
This fixes the bug mentioned in #154. 

I've noticed that google play is loading the content sending `POST` requests instead `GET`, also passing the start param in the req form instead of in the querystring. 

Hope you enjoy it. 