### PR TITLE
Fixs cache param in search method when fullDetail is true

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -124,7 +124,8 @@ function search (opts) {
       fullDetail: opts.fullDetail,
       price: opts.price ? getPriceGoogleValue(opts.price) : 0,
       throttle: opts.throttle,
-      proxy: opts.proxy
+      proxy: opts.proxy,
+      cache: opts.cache
     };
 
     initialRequest(opts)


### PR DESCRIPTION
Just realized that when the param `fullDetail` is `true` in `search` method, the `cache: false` param was not working as expected. This pr should fix it. 