### PR TITLE
Sets num param default to 20 in developer method

### DIFF
--- a/lib/developer.js
+++ b/lib/developer.js
@@ -72,7 +72,7 @@ function developer (opts) {
     }
 
     opts = Object.assign({
-      num: 60,
+      num: 20,
       lang: 'en',
       country: 'us'
     }, opts);


### PR DESCRIPTION
According to docs, the defalut value to `num` param in developer method should be `20`, however, it was `60`.