### PR TITLE
Fixed 'Full review' link for multi languaje support

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -61,7 +61,8 @@ function parseFields ($) {
 
     const reviewContent = $(this).find('.review-body');
     const title = reviewContent.find('span[class=review-title]').text().trim();
-    const text = filterReviewText(reviewContent.text().trim(), title.length);
+    reviewContent.find('.review-link').remove();
+    const text = reviewContent.text().trim();
 
     const developerComment = $(this).next('.developer-reply');
     let replyDate;
@@ -100,12 +101,6 @@ function validate (opts) {
   if (opts.page && opts.page < 0) {
     throw new Error('Page cannot be lower than 0');
   }
-}
-
-function filterReviewText (text, startIndex) {
-  const regex = /Full Review/;
-  const result = text.substring(startIndex).replace(regex, '').trim();
-  return result;
 }
 
 function filterScore (score) {


### PR DESCRIPTION
Removes 'Opinión completa' in spanish, and probably many other languajes 'Full review' link, from review comment text.

Fixes: #168