### PR TITLE
Pass lang param to redirected URL when fetching similar apps

### DIFF
--- a/lib/similar.js
+++ b/lib/similar.js
@@ -13,11 +13,22 @@ function similar (getParseList, opts) {
     const appId = encodeURIComponent(opts.appId);
 
     const options = {
-      url: `https://play.google.com/store/apps/similar?id=${appId}&hl=${opts.lang}`,
-      proxy: opts.proxy
+      url: `https://play.google.com/store/apps/similar?id=${appId}`,
+      proxy: opts.proxy,
+      followRedirect: false // Don't follow redirects, because we need to add lang param to it
     };
 
     request(options, opts.throttle)
+      .then(response => {
+        if (response.statusCode > 300 && response.headers && response.headers.location) {
+          const redirectOpts = {
+            url: `${response.headers.location}&hl=${opts.lang}`,
+            proxy: opts.proxy
+          };
+          return request(redirectOpts, opts.throttle);
+        }
+        return response;
+      })
       .then(cheerio.load)
       .then(getParseList(opts))
       .then(resolve)

--- a/lib/utils/request.js
+++ b/lib/utils/request.js
@@ -21,6 +21,11 @@ function doRequest (opts, limit) {
     if (response.statusCode >= 400) {
       return reject({response});
     }
+    // Sometimes we want to return redirect response as is,
+    // since we need to add extra params to it's location
+    if (response.statusCode >= 300) {
+      return resolve(response);
+    }
     resolve(body);
   }));
 }

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
   "homepage": "https://github.com/facundoolano/google-play-scraper",
   "dependencies": {
     "cheerio": "^0.20.0",
-    "debug": "^2.2.0",
+    "debug": "^2.6.9",
     "memoizee": "^0.4.11",
     "ramda": "^0.21.0",
-    "request": "^2.79.0",
+    "request": "^2.83.0",
     "throttled-request": "^0.1.1"
   },
   "devDependencies": {

--- a/test/common.js
+++ b/test/common.js
@@ -3,6 +3,8 @@
 const assert = require('chai').assert;
 const validator = require('validator');
 
+const cyrillicCharacters = /[а-яА-ЯёЁ]/;
+
 function assertValidUrl (url) {
   return assert(validator.isURL(url, {allow_protocol_relative_urls: true}),
                                `${url} is not a valid url`);
@@ -28,4 +30,9 @@ function assertValidApp (app) {
   return app;
 }
 
-module.exports = { assertValidUrl, assertValidApp };
+function assertCyrillic (apps) {
+  const appWithRussianSummary = apps.find(app => cyrillicCharacters.test(app.summary));
+  assert.isOk(appWithRussianSummary);
+}
+
+module.exports = { assertValidUrl, assertValidApp, assertCyrillic };

--- a/test/lib.similar.js
+++ b/test/lib.similar.js
@@ -1,11 +1,17 @@
 'use strict';
 
 const gplay = require('../index');
-const assertValidApp = require('./common').assertValidApp;
+const {assertValidApp, assertCyrillic} = require('./common');
 
 describe('Similar method', () => {
   it('should fetch a valid application list', () => {
     return gplay.similar({appId: 'com.dxco.pandavszombies'})
-    .then((apps) => apps.map(assertValidApp));
+      .then((apps) => apps.map(assertValidApp));
+  });
+
+  it('should respect passed language param', () => {
+    return gplay.similar({appId: 'com.dxco.pandavszombies', lang: 'ru'})
+      .then((apps) => apps.map(assertValidApp))
+      .then(assertCyrillic);
   });
 });


### PR DESCRIPTION
Probably Google changed the way similar apps API works. So now request like
```
$ curl -I "https://play.google.com/store/apps/similar?id=com.chillingo.micromachines.android.gplay&hl=ru"
```
doesn't render HTML page with similar apps, but instead redirects like this:
```
HTTP/2 302
content-type: text/html; charset=UTF-8
...snip...
location: https://play.google.com/store/apps/collection/similar?clp=qgExCi8KKWNvbS5jaGlsbGluZ28ubWljcm9tYWNoaW5lcy5hbmRyb2lkLmdwbGF5EAEYAw%3D%3D:S:ANO1ljJ6vVU
```
The location it redirects to returns list of similar games, but using client's geo/language settings/etc.
Luckily that location also accepts `hl` parameter, so we can force which language we want back.

So essentially this PR
- allows to ask internal request library not to redirect
- appends `hl` param to location we redirect to, if such is found

I also added a simple test that tries to fetch similar apps using Russian, and then makes sure that at least some of the received summaries contain Cyrillic characters.