### PR TITLE
Fixes TypeError: Cannot read property 'split' of undefined

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -42,6 +42,7 @@ function app (opts) {
 }
 
 function parseFields ($) {
+  if (!!$('head > base').attr('href')) return {};
   const detailsInfo = $('.details-info');
   const title = detailsInfo.find('.document-title').text().trim();
   const developer = detailsInfo.find('span[itemprop="name"]').text();


### PR DESCRIPTION
Fixes a rare case of `TypeError: Cannot read property 'split' of undefined`

----

@facundoolano 