### PR TITLE
Parse app detail based on script tags data

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,43 +42,49 @@ gplay.app({appId: 'com.dxco.pandavszombies'})
 Results:
 
 ```javascript
-{
-  appId: 'com.dxco.pandavszombies',
-  title: 'Panda vs Zombie: Elvis rage',
+{ appId: 'com.dxco.pandavszombies',
+  url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&hl=en&gl=us'
+  title: 'Panda vs Zombies',
+  description: 'Panda, my friend, Panda is the answer. But not any Panda: Rocky the Panda!',
+  descriptionHTML: 'Panda, my friend, Panda is the answer. But not any Panda: <b>Rocky the Panda!</b>',
   summary: 'Help Rocky the Panda warrior to fight zombie games and save the Panda kind.',
-  url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&hl=en',
-  icon: 'https://lh6.ggpht.com/5mI27oolnooL__S3ns9qAf_6TsFNExMtUAwTKz6prWCxEmVkmZZZwe3lI-ZLbMawEJh3=w300',
+  installs: '10,000+',
   minInstalls: 10000,
-  maxInstalls: 50000,
-  score: 4.9,
-  reviews: 2312,
-  histogram: { '1': 12, '2': 7, '3': 16, '4': 40, '5': 231 },
-  description: 'Everyone in town has gone zombie.',
-  developerId: "DxCo+Games",
-  descriptionHTML: 'Everyone in town has gone <b>zombie</b>.',
+  score: 4.5025907,
+  scoreText: '4.5',
+  ratings: 386,
+  reviews: 168,
+  histogram: { '1': 14, '2': 11, '3': 26, '4': 51, '5': 284 },
+  price: 0,
+  free: true,
+  currency: 'USD',
+  priceText: 'Free',
+  offersIAP: false,
+  size: '34M',
+  androidVersion: '2.3',
+  androidVersionText: '2.3 and up',
   developer: 'DxCo Games',
+  developerId: 'DxCo+Games',
   developerEmail: 'dxcogames@gmail.com',
   developerWebsite: 'http://www.dxco-games.com/',
-  developerAddress: '10685-B Hazelhurst Dr. # 18457\nHouston, TX 77043\nUSA',
-  updated: 'May 26, 2015',
+  developerAddress: undefined,
   genre: 'Action',
   genreId: 'GAME_ACTION',
   familyGenre: undefined,
   familyGenreId: undefined,
-  version: '1.4',
-  size: '34M',
-  androidVersionText: '2.3 and up',
-  androidVersion: '2.3',
+  icon: 'https://lh6.ggpht.com/5mI27oolnooL__S3ns9qAf_6TsFNExMtUAwTKz6prWCxEmVkmZZZwe3lI-ZLbMawEJh3',
+  headerImage: 'https://lh4.ggpht.com/kKfRICvVTCikV4MLqsP0kWEth2F-I1Qt4jxMdklOdE2r8AmtrE-Umn6_WH_cGExXnjk-',
+  screenshots: [ 'https://lh5.ggpht.com/gD8L81t4CFKI21aOVkSnfVHioInwnt0XxMMWA-dBB2aU5bk3UfxGn8Hcq_KxcM6m430'],
+  video: 'https://www.youtube.com/embed/PFGj-W8Pe5s?ps=play&vq=large&rel=0&autohide=1&showinfo=0',
+  videoImage: 'https://i.ytimg.com/vi/PFGj-W8Pe5s/hqdefault.jpg',
   contentRating: 'Mature 17+',
-  price: '0',
-  free: true,
-  offersIAP: false,
-  screenshots: ['https://lh3.ggpht.com/le0bhlp7RTGDytoXelnY65Cx4pjUgVjnLypDGGWGfF6SbDMTkU6fPncaAH8Ew9RQAeY=h310']
-  video: 'https://www.youtube.com/embed/PFGj-W8Pe5s',
-  comments: ['Great! Its a great time waster'],
-  recentChanges: [ '- Added a hint system' ],
-  preregister: false
-}
+  contentRatingDescription: 'Violence, Blood and Gore',
+  adSupported: true,
+  updated: 'Feb 27, 2015',
+  version: '1.4',
+  recentChanges: '- Added a hint system<br>- Added share option in level finished',
+  comments: [ 'Great!', 'PvZ', 'LOL', 'Zombie killer', 'Una pasada' ]
+  }
 ```
 
 ### list
@@ -116,7 +122,8 @@ Results:
     title: 'Bus Rush',
     icon: 'https://lh3.googleusercontent.com/R6hmyJ6ls6wskk5hHFoW02yEyJpSG36il4JBkVf-Aojb1q4ZJ9nrGsx6lwsRtnTqfA=w340',
     score: 3.9,
-    price: '0',
+    scoreText: '3.9',
+    priceText: 'Free',
     free: false },
   { url: 'https://play.google.com/store/apps/details?id=com.yodo1.crossyroad',
     appId: 'com.yodo1.crossyroad',
@@ -126,7 +133,8 @@ Results:
     developerId: 'Yodo1+Games',
     icon: 'https://lh3.googleusercontent.com/doHqbSPNekdR694M-4rAu9P2B3V6ivff76fqItheZGJiN4NBw6TrxhIxCEpqgO3jKVg=w340',
     score: 4.5,
-    price: '0',
+    scoreText: '4.5',
+    priceText: 'Free',
     free: false } ]
 ```
 
@@ -165,7 +173,8 @@ Results:
     developerId: 'Snail+Games+USA+Inc',
     icon: 'https://lh3.googleusercontent.com/g8RMjpRk9yetsui4g5lxnioAFwtgoKUJDBnb2knJMrOaLOtHrwU1qYkb-PadbL0Zmg=w340',
     score: 4.1,
-    price: '0',
+    scoreText: '4.1',
+    priceText: 'Free',
     free: true },
   { url: 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp',
     appId: 'com.sgn.pandapop.gp',
@@ -175,7 +184,8 @@ Results:
     developerId: '5509190841173705883',
     icon: 'https://lh5.ggpht.com/uAAUBzEHtD_-mTxomL2wFxb5VSdtNllk9M4wjVdTGMD8pH79RtWGYQYrrtfVTjq7PV7M=w340',
     score: 4.2,
-    price: '0',
+    scoreText: '4.2',
+    priceText: 'Free',
     free: true } ]
 ```
 
@@ -206,7 +216,8 @@ Results:
     developerId: 'DxCo+Games',
     icon: 'https://lh3.googleusercontent.com/kFco0LtC7ICP0QrtpkF-QQahU-iwuDgEsH0AClQcHwtzsO5-8BGTf8QgR6dlCLxqBLc=w340',
     score: 3.9,
-    price: '0',
+    scoreText: '3.9',
+    priceText: 'Free',
     free: true },
   { url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies',
     appId: 'com.dxco.pandavszombies',
@@ -216,7 +227,8 @@ Results:
     developerId: 'DxCo+Games',
     icon: 'https://lh6.ggpht.com/5mI27oolnooL__S3ns9qAf_6TsFNExMtUAwTKz6prWCxEmVkmZZZwe3lI-ZLbMawEJh3=w340',
     score: 4.5,
-    price: '0',
+    scoreText: '4.5',
+    priceText: 'Free',
     free: true } ]
 ```
 
@@ -270,6 +282,7 @@ Results:
     userImage: 'https://lh3.googleusercontent.com/-hBGvzn3XlhQ/AAAAAAAAAAI/AAAAAAAAOw0/L4GY9KrQ-DU/w96-c-h96/photo.jpg',
     date: 'June 7, 2015',
     score: 5,
+    scoreText: '5',
     url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRWZaVHVZZ081NlNsRW9TV0hJeklGSTBvYTBTUlFQUUJIZThBSGJDX2s1Y1o0ZXRCbUtLZmgzTE1PMUttRmpRSS1YcFgxRmx1ZXNtVzlVS0Zz'
     title: 'I LOVE IT',
     text: 'It has skins and snowballs everything I wanted its so cool I love it!!!!!!!!',
@@ -281,6 +294,7 @@ Results:
     date: 'January 24, 2015',
     url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRmFHdlBFS2pGS2JVYW5Dd3kxTm1qUzRxQlYyc3Z4ZE9CYXRuc0hkclV3a09hbEFkOVdoWmw3eFN5VjF4cDJPLTg5TW5ZUjl1Zm9HOWc5NGtr',
     score: 5,
+    scoreText: '5',
     title: 'CAN NEVER WAIT TILL NEW UPDATE',
     text: 'Love it but needs to pay more attention to pocket edition',
     replyDate: undefined,
@@ -311,7 +325,8 @@ Results:
     developerId: '8812103738509382093',
     icon: '//lh3.googleusercontent.com/QDRAv7v4LSCfZgz3GIbOSz8Zj8rWqeeYuqqYiqyQXkxRJwG7vvUltzsFaWK5D7-JMnIZ=w340',
     score: 3.3,
-    price: '$2.16',
+    scoreText: '3.3',
+    priceText: '$2.16',
     free: false } ]
 ```
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -77,9 +77,16 @@ const MAPPINGS = {
     fun: buildHistogram
   },
 
-  // FIXME should be 0 for free apps
-  // TODO add free boolean
-  price: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 2],
+  price: {
+    path: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 0],
+    fun: (val) => val / 1000000
+  },
+  free: {
+    path: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 0],
+    fun: (val) => val === 0
+  },
+  currency: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 1],
+  priceText: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 2],
 
   size: ['ds:5', 0],
   androidVersion: {

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const request = require('./utils/request');
-const cheerio = require('cheerio');
 const queryString = require('querystring');
-const url = require('url');
 const R = require('ramda');
 
 const PLAYSTORE_URL = 'https://play.google.com/store/apps/details';
@@ -30,167 +28,214 @@ function app (opts) {
     }, opts.requestOptions);
 
     request(options, opts.throttle)
-      .then(cheerio.load)
-      .then(parseFields)
-      .then(function (app) {
-        app.url = reqUrl;
-        app.appId = opts.appId;
-        resolve(app);
-      })
+      .then(matchScriptData)
+      // comment next line to get raw data
+      .then(extractFields)
+      .then(resolve)
       .catch(reject);
   });
 }
 
-function parseFields ($) {
-  const detailsInfo = $('.details-info');
-  const title = detailsInfo.find('.document-title').text().trim();
-  const developer = detailsInfo.find('span[itemprop="name"]').text();
-  const developerId = detailsInfo.find('.primary').attr('href').split('id=')[1];
-  const summary = $('meta[name="description"]').attr('content');
+/*
+ * Extract the javascript objects returned by the AF_initDataCallback functions
+ * in the script tags of the app detail HTML.
+ */
+function matchScriptData (response) {
+  const scriptRegex = />AF_initDataCallback[\s\S]*?<\/script/g;
+  const keyRegex = /(ds:.*?)'/;
+  const valueRegex = /return ([\s\S]*?)}}\);<\//;
 
-  const mainGenre = detailsInfo.find('.category').first();
-  const genreText = mainGenre.text().trim();
-  const genreId = mainGenre.attr('href').split('/')[4];
+  return response.match(scriptRegex)
+    .reduce((accum, data) => {
+      const keyMatch = data.match(keyRegex);
+      const valueMatch = data.match(valueRegex);
 
-  const familyGenre = detailsInfo.find('.category[href*="FAMILY"]');
-  let familyGenreText;
-  let familyGenreId;
-  if (familyGenre.length) {
-    familyGenreText = familyGenre.text().trim() || undefined;
-    familyGenreId = familyGenre.attr('href').split('/')[4];
-  }
-
-  const price = detailsInfo.find('meta[itemprop=price]').attr('content');
-  const icon = detailsInfo.find('img.cover-image').attr('src');
-  const offersIAP = !!detailsInfo.find('.inapp-msg').length;
-  const adSupported = !!detailsInfo.find('.ads-supported-label-msg').length;
-
-  const additionalInfo = $('.details-section-contents');
-  const description = additionalInfo.find('div[itemprop=description] div');
-  const version = additionalInfo.find('div.content[itemprop="softwareVersion"]').text().trim();
-  const updated = additionalInfo.find('div.content[itemprop="datePublished"]').text().trim();
-  const androidVersionText = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
-  const androidVersion = normalizeAndroidVersion(androidVersionText);
-  const contentRating = additionalInfo.find('div.content[itemprop="contentRating"]').text().trim();
-  const size = additionalInfo.find('div.content[itemprop="fileSize"]').text().trim();
-
-  let maxInstalls, minInstalls;
-  const preregister = !!$('.preregistration-container').length;
-  if (!preregister) {
-    const installs = installNumbers(additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim());
-    minInstalls = cleanInt(installs[0]);
-    maxInstalls = cleanInt(installs[1]);
-  }
-
-  let developerEmail = additionalInfo.find('.dev-link[href^="mailto:"]').attr('href');
-  if (developerEmail) {
-    developerEmail = developerEmail.split(':')[1];
-  }
-
-  let developerWebsite = additionalInfo.find('.dev-link[href^="http"]').attr('href');
-  if (developerWebsite) {
-    // extract clean url wrapped in google url
-    developerWebsite = url.parse(developerWebsite, true).query.q;
-  }
-
-  const developerAddress = additionalInfo.find('.physical-address').text().trim();
-
-  const comments = $('.quoted-review').toArray().map((elem) => $(elem).text().trim());
-  const ratingBox = $('.rating-box');
-  const reviews = cleanInt(ratingBox.find('span.reviews-num').text());
-
-  const ratingHistogram = $('.rating-histogram');
-  const histogram = {
-    5: cleanInt(ratingHistogram.find('.five .bar-number').text()),
-    4: cleanInt(ratingHistogram.find('.four .bar-number').text()),
-    3: cleanInt(ratingHistogram.find('.three .bar-number').text()),
-    2: cleanInt(ratingHistogram.find('.two .bar-number').text()),
-    1: cleanInt(ratingHistogram.find('.one .bar-number').text())
-  };
-  // for other languages
-  const score = parseFloat(ratingBox.find('div.score').text().replace(',', '.')) || 0;
-
-  let video = $('.screenshots span.preview-overlay-container[data-video-url]').attr('data-video-url');
-  if (video) {
-    video = video.split('?')[0];
-  }
-
-  const screenshots = $('.thumbnails .screenshot').toArray().map((elem) => $(elem).attr('src'));
-  const recentChanges = $('.recent-change').toArray().map((elem) => $(elem).text());
-
-  const fields = {
-    title,
-    summary,
-    icon,
-    price,
-    free: price === '0',
-    minInstalls,
-    maxInstalls,
-    score,
-    reviews,
-    developer,
-    developerId,
-    developerEmail,
-    developerWebsite,
-    developerAddress,
-    updated,
-    version,
-    genre: genreText,
-    genreId,
-    familyGenre: familyGenreText,
-    familyGenreId,
-    size,
-    description: descriptionText(description),
-    descriptionHTML: description.html(),
-    histogram,
-    offersIAP,
-    adSupported,
-    androidVersionText,
-    androidVersion,
-    contentRating,
-    screenshots,
-    video,
-    comments,
-    recentChanges,
-    preregister
-  };
-
-  // replace blank values with undefined
-  return R.map((field) => field === '' ? undefined : field, fields);
-}
-function descriptionText (description) {
-  // preserve the line breaks when converting to text
-  const html = '<div>' + description.html().replace(/<\/p>/g, '\n</p>') + '</div>';
-  return cheerio.load(html)('div').text();
+      if (keyMatch && valueMatch) {
+        const key = keyMatch[1];
+        const value = JSON.parse(valueMatch[1]);
+        return R.assoc(key, value, accum);
+      }
+      return accum;
+    }, {});
 }
 
-function cleanInt (number) {
-  number = number || '0';
-  // removes thousands separator
-  number = number.replace(/\D/g, '');
-  return parseInt(number);
+const MAPPINGS = {
+  title: ['ds:3', 0, 0, 0],
+  description: ['ds:3', 0, 10, 0, 1],
+  developer: ['ds:3', 0, 12, 5, 1],
+  developerId: {
+    path: ['ds:3', 0, 12, 5, 5, 4, 2],
+    fun: (devUrl) => devUrl.split('id=')[1]
+  },
+  developerEmail: ['ds:3', 0, 12, 5, 2, 0],
+  developerWebsite: ['ds:3', 0, 12, 5, 3, 5, 2]
+};
+
+/*
+ * Map the MAPPINGS object, applying each field spec to the parsed data.
+ * If the mapping value is an array, use it as the path to the extract the
+ * field's value. If it's an object, extract the value in object.path and pass
+ * it to the function in object.fun
+ */
+function extractFields (parsedData) {
+  return R.map((spec) => {
+    if (R.is(Array, spec)) {
+      return R.path(spec, parsedData);
+    }
+    // assume spec object
+    const input = R.path(spec.path, parsedData);
+    return spec.fun(input);
+  }, MAPPINGS);
 }
 
-function installNumbers (downloads) {
-  if (!downloads) {
-    return [0, 0];
-  }
+// FIXME old code kept for reference, remove when done migrating
 
-  const characters = [' - ', ' et ', '–', '-', '～', ' a '];
-  const char = characters.find((char) => downloads.split(char).length === 2);
-  if (char) return downloads.split(char);
+// function parseFields ($) {
+//   const summary = $('meta[name="description"]').attr('content');
 
-  throw new Error(`Unable to parse min/max downloads: ${downloads}`);
-}
+//   const mainGenre = detailsInfo.find('.category').first();
+//   const genreText = mainGenre.text().trim();
+//   const genreId = mainGenre.attr('href').split('/')[4];
 
-function normalizeAndroidVersion (androidVersionText) {
-  let matches = androidVersionText.match(/^([0-9\.]+)[^0-9\.].+/);
+//   const familyGenre = detailsInfo.find('.category[href*="FAMILY"]');
+//   let familyGenreText;
+//   let familyGenreId;
+//   if (familyGenre.length) {
+//     familyGenreText = familyGenre.text().trim() || undefined;
+//     familyGenreId = familyGenre.attr('href').split('/')[4];
+//   }
 
-  if (!matches || typeof matches[1] === 'undefined') {
-    return 'VARY';
-  }
+//   const price = detailsInfo.find('meta[itemprop=price]').attr('content');
+//   const icon = detailsInfo.find('img.cover-image').attr('src');
+//   const offersIAP = !!detailsInfo.find('.inapp-msg').length;
+//   const adSupported = !!detailsInfo.find('.ads-supported-label-msg').length;
 
-  return matches[1];
-}
+//   const additionalInfo = $('.details-section-contents');
+//   const description = additionalInfo.find('div[itemprop=description] div');
+//   const version = additionalInfo.find('div.content[itemprop="softwareVersion"]').text().trim();
+//   const updated = additionalInfo.find('div.content[itemprop="datePublished"]').text().trim();
+//   const androidVersionText = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
+//   const androidVersion = normalizeAndroidVersion(androidVersionText);
+//   const contentRating = additionalInfo.find('div.content[itemprop="contentRating"]').text().trim();
+//   const size = additionalInfo.find('div.content[itemprop="fileSize"]').text().trim();
+
+//   let maxInstalls, minInstalls;
+//   const preregister = !!$('.preregistration-container').length;
+//   if (!preregister) {
+//     const installs = installNumbers(additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim());
+//     minInstalls = cleanInt(installs[0]);
+//     maxInstalls = cleanInt(installs[1]);
+//   }
+
+//   let developerEmail = additionalInfo.find('.dev-link[href^="mailto:"]').attr('href');
+//   if (developerEmail) {
+//     developerEmail = developerEmail.split(':')[1];
+//   }
+
+//   let developerWebsite = additionalInfo.find('.dev-link[href^="http"]').attr('href');
+//   if (developerWebsite) {
+//     // extract clean url wrapped in google url
+//     developerWebsite = url.parse(developerWebsite, true).query.q;
+//   }
+
+//   const developerAddress = additionalInfo.find('.physical-address').text().trim();
+
+//   const comments = $('.quoted-review').toArray().map((elem) => $(elem).text().trim());
+//   const ratingBox = $('.rating-box');
+//   const reviews = cleanInt(ratingBox.find('span.reviews-num').text());
+
+//   const ratingHistogram = $('.rating-histogram');
+//   const histogram = {
+//     5: cleanInt(ratingHistogram.find('.five .bar-number').text()),
+//     4: cleanInt(ratingHistogram.find('.four .bar-number').text()),
+//     3: cleanInt(ratingHistogram.find('.three .bar-number').text()),
+//     2: cleanInt(ratingHistogram.find('.two .bar-number').text()),
+//     1: cleanInt(ratingHistogram.find('.one .bar-number').text())
+//   };
+//   // for other languages
+//   const score = parseFloat(ratingBox.find('div.score').text().replace(',', '.')) || 0;
+
+//   let video = $('.screenshots span.preview-overlay-container[data-video-url]').attr('data-video-url');
+//   if (video) {
+//     video = video.split('?')[0];
+//   }
+
+//   const screenshots = $('.thumbnails .screenshot').toArray().map((elem) => $(elem).attr('src'));
+//   const recentChanges = $('.recent-change').toArray().map((elem) => $(elem).text());
+
+//   const fields = {
+//     title,
+//     summary,
+//     icon,
+//     price,
+//     free: price === '0',
+//     minInstalls,
+//     maxInstalls,
+//     score,
+//     reviews,
+//     developer,
+//     developerId,
+//     developerEmail,
+//     developerWebsite,
+//     developerAddress,
+//     updated,
+//     version,
+//     genre: genreText,
+//     genreId,
+//     familyGenre: familyGenreText,
+//     familyGenreId,
+//     size,
+//     description: descriptionText(description),
+//     descriptionHTML: description.html(),
+//     histogram,
+//     offersIAP,
+//     adSupported,
+//     androidVersionText,
+//     androidVersion,
+//     contentRating,
+//     screenshots,
+//     video,
+//     comments,
+//     recentChanges,
+//     preregister
+//   };
+
+//   // replace blank values with undefined
+//   return R.map((field) => field === '' ? undefined : field, fields);
+// }
+// function descriptionText (description) {
+//   // preserve the line breaks when converting to text
+//   const html = '<div>' + description.html().replace(/<\/p>/g, '\n</p>') + '</div>';
+//   return cheerio.load(html)('div').text();
+// }
+
+// function cleanInt (number) {
+//   number = number || '0';
+//   // removes thousands separator
+//   number = number.replace(/\D/g, '');
+//   return parseInt(number);
+// }
+
+// function installNumbers (downloads) {
+//   if (!downloads) {
+//     return [0, 0];
+//   }
+
+//   const characters = [' - ', ' et ', '–', '-', '～', ' a '];
+//   const char = characters.find((char) => downloads.split(char).length === 2);
+//   if (char) return downloads.split(char);
+
+//   throw new Error(`Unable to parse min/max downloads: ${downloads}`);
+// }
+
+// function normalizeAndroidVersion (androidVersionText) {
+//   let matches = androidVersionText.match(/^([0-9\.]+)[^0-9\.].+/);
+
+//   if (!matches || typeof matches[1] === 'undefined') {
+//     return 'VARY';
+//   }
+
+//   return matches[1];
+// }
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -66,7 +66,18 @@ const MAPPINGS = {
   description: ['ds:3', 0, 10, 0, 1],
   summary: ['ds:3', 0, 10, 1, 1],
   installs: ['ds:3', 0, 12, 9, 0],
+  score: ['ds:10', 0, 0, 1],
+  scoreText: ['ds:10', 0, 0, 0],
 
+  // FIXME should be 0 for free apps
+  // TODO add free boolean
+  price: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 2],
+
+  size: ['ds:5', 0],
+  androidVersion: {
+    path: ['ds:5', 2],
+    fun: normalizeAndroidVersion
+  },
 
   developer: ['ds:3', 0, 12, 5, 1],
   developerId: {
@@ -75,6 +86,7 @@ const MAPPINGS = {
   },
   developerEmail: ['ds:3', 0, 12, 5, 2, 0],
   developerWebsite: ['ds:3', 0, 12, 5, 3, 5, 2],
+  developerAddress: ['ds:3', 0, 12, 5, 4, 0],
 
   genre: ['ds:3', 0, 12, 13, 0, 0],
   genreId: ['ds:3', 0, 12, 13, 0, 2],
@@ -90,8 +102,14 @@ const MAPPINGS = {
 
   contentRating: ['ds:3', 0, 12, 4, 0],
   contentRatingDescription: ['ds:3', 0, 12, 4, 2, 1],
+  adSupported: {
+    path: ['ds:3', 0, 12, 14, 0],
+    fun: Boolean
+  },
 
   updated: ['ds:3', 0, 12, 36],
+
+  version: ['ds:5', 1],
   recentChanges: ['ds:3', 0, 12, 6, 1]
 };
 
@@ -126,12 +144,6 @@ function extractFields (parsedData) {
 
 //   const price = detailsInfo.find('meta[itemprop=price]').attr('content');
 //   const offersIAP = !!detailsInfo.find('.inapp-msg').length;
-//   const adSupported = !!detailsInfo.find('.ads-supported-label-msg').length;
-
-//   const version = additionalInfo.find('div.content[itemprop="softwareVersion"]').text().trim();
-//   const androidVersionText = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
-//   const androidVersion = normalizeAndroidVersion(androidVersionText);
-//   const size = additionalInfo.find('div.content[itemprop="fileSize"]').text().trim();
 
 //   let maxInstalls, minInstalls;
 //   const preregister = !!$('.preregistration-container').length;
@@ -140,8 +152,6 @@ function extractFields (parsedData) {
 //     minInstalls = cleanInt(installs[0]);
 //     maxInstalls = cleanInt(installs[1]);
 //   }
-
-//   const developerAddress = additionalInfo.find('.physical-address').text().trim();
 
 //   const comments = $('.quoted-review').toArray().map((elem) => $(elem).text().trim());
 //   const ratingBox = $('.rating-box');
@@ -155,8 +165,6 @@ function extractFields (parsedData) {
 //     2: cleanInt(ratingHistogram.find('.two .bar-number').text()),
 //     1: cleanInt(ratingHistogram.find('.one .bar-number').text())
 //   };
-//   // for other languages
-//   const score = parseFloat(ratingBox.find('div.score').text().replace(',', '.')) || 0;
 
 //   const fields = {
 //     title,
@@ -223,14 +231,12 @@ function extractFields (parsedData) {
 //   throw new Error(`Unable to parse min/max downloads: ${downloads}`);
 // }
 
-// function normalizeAndroidVersion (androidVersionText) {
-//   let matches = androidVersionText.match(/^([0-9\.]+)[^0-9\.].+/);
-
-//   if (!matches || typeof matches[1] === 'undefined') {
-//     return 'VARY';
-//   }
-
-//   return matches[1];
-// }
+function normalizeAndroidVersion (androidVersionText) {
+  const number = androidVersionText.split(' ')[0];
+  if (parseFloat(number)) {
+    return number;
+  }
+  return 'VARY';
+}
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -94,7 +94,8 @@ const MAPPINGS = {
   },
   free: {
     path: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 0],
-    fun: (val) => val === 0 || val === undefined
+    // considered free only if prize is exactly zero
+    fun: (val) => val === 0
   },
   currency: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 1],
   priceText: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 2],
@@ -168,78 +169,11 @@ function extractFields (parsedData) {
   }, MAPPINGS);
 }
 
-// FIXME old code kept for reference, remove when done migrating
-
-// function parseFields ($) {
-
-//   const familyGenre = detailsInfo.find('.category[href*="FAMILY"]');
-//   let familyGenreText;
-//   let familyGenreId;
-//   if (familyGenre.length) {
-//     familyGenreText = familyGenre.text().trim() || undefined;
-//     familyGenreId = familyGenre.attr('href').split('/')[4];
-//   }
-
-//   const offersIAP = !!detailsInfo.find('.inapp-msg').length;
-
-//   const preregister = !!$('.preregistration-container').length;
-//     maxInstalls = cleanInt(installs[1]);
-
-//   const fields = {
-//     title,
-//     summary,
-//     icon,
-//     price,
-//     free: price === '0',
-//     minInstalls,
-//     maxInstalls,
-//     score,
-//     reviews,
-//     developer,
-//     developerId,
-//     developerEmail,
-//     developerWebsite,
-//     developerAddress,
-//     updated,
-//     version,
-//     genre: genreText,
-//     genreId,
-//     familyGenre: familyGenreText,
-//     familyGenreId,
-//     size,
-//     description: descriptionText(description),
-//     descriptionHTML: description.html(),
-//     histogram,
-//     offersIAP,
-//     adSupported,
-//     androidVersionText,
-//     androidVersion,
-//     contentRating,
-//     screenshots,
-//     video,
-//     comments,
-//     recentChanges,
-//     preregister
-//   };
-
-// }
 function descriptionText (description) {
   // preserve the line breaks when converting to text
   const html = cheerio.load('<div>' + description.replace(/<br>/g, '\r\n') + '</div>');
   return cheerio.text(html('div'));
 }
-
-// function installNumbers (downloads) {
-//   if (!downloads) {
-//     return [0, 0];
-//   }
-
-//   const characters = [' - ', ' et ', '–', '-', '～', ' a '];
-//   const char = characters.find((char) => downloads.split(char).length === 2);
-//   if (char) return downloads.split(char);
-
-//   throw new Error(`Unable to parse min/max downloads: ${downloads}`);
-// }
 
 function cleanInt (number) {
   number = number || '0';

--- a/lib/app.js
+++ b/lib/app.js
@@ -275,7 +275,7 @@ function extractComments (comments) {
   return R.compose(
     R.take(5),
     R.reject(R.isNil),
-    R.pluck(4))(comments);
+    R.pluck(3))(comments);
 }
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -31,6 +31,8 @@ function app (opts) {
       .then(matchScriptData)
       // comment next line to get raw data
       .then(extractFields)
+      .then(R.assoc('appId', opts.appId))
+      .then(R.assoc('url', reqUrl))
       .then(resolve)
       .catch(reject);
   });
@@ -68,11 +70,15 @@ const MAPPINGS = {
   description: ['ds:3', 0, 10, 0, 1],
   summary: ['ds:3', 0, 10, 1, 1],
   installs: ['ds:3', 0, 12, 9, 0],
+  minInstalls: {
+    path: ['ds:3', 0, 12, 9, 0],
+    fun: (text) => parseInt(text.replace(/[^\d]/g, ''))
+  },
   score: ['ds:10', 0, 0, 1],
   scoreText: ['ds:10', 0, 0, 0],
   ratings: ['ds:10', 0, 2, 1],
   reviews: ['ds:10', 0, 3, 1],
-  ratingHistogram: {
+  histogram: {
     path: ['ds:10', 0, 1],
     fun: buildHistogram
   },
@@ -93,6 +99,7 @@ const MAPPINGS = {
     path: ['ds:5', 2],
     fun: normalizeAndroidVersion
   },
+  androidVersionText: ['ds:5', 2],
 
   developer: ['ds:3', 0, 12, 5, 1],
   developerId: {
@@ -125,7 +132,12 @@ const MAPPINGS = {
   updated: ['ds:3', 0, 12, 36],
 
   version: ['ds:5', 1],
-  recentChanges: ['ds:3', 0, 12, 6, 1]
+  recentChanges: ['ds:3', 0, 12, 6, 1],
+  comments: {
+    path: ['ds:13', 0],
+    fun: extractComments
+  }
+
 };
 
 /*
@@ -167,8 +179,6 @@ function extractFields (parsedData) {
 //     minInstalls = cleanInt(installs[0]);
 //     maxInstalls = cleanInt(installs[1]);
 //   }
-
-//   const comments = $('.quoted-review').toArray().map((elem) => $(elem).text().trim());
 
 //   const fields = {
 //     title,
@@ -242,6 +252,13 @@ function buildHistogram (container) {
     4: container[4][1],
     5: container[5][1]
   };
+}
+
+function extractComments (comments) {
+  return R.compose(
+    R.take(5),
+    R.reject(R.isNil),
+    R.pluck(3))(comments);
 }
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -169,16 +169,10 @@ function extractFields (parsedData) {
 //     familyGenreId = familyGenre.attr('href').split('/')[4];
 //   }
 
-//   const price = detailsInfo.find('meta[itemprop=price]').attr('content');
 //   const offersIAP = !!detailsInfo.find('.inapp-msg').length;
 
-//   let maxInstalls, minInstalls;
 //   const preregister = !!$('.preregistration-container').length;
-//   if (!preregister) {
-//     const installs = installNumbers(additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim());
-//     minInstalls = cleanInt(installs[0]);
 //     maxInstalls = cleanInt(installs[1]);
-//   }
 
 //   const fields = {
 //     title,

--- a/lib/app.js
+++ b/lib/app.js
@@ -62,12 +62,20 @@ function matchScriptData (response) {
 // TODO may need to do html to text in some of the fields
 
 const MAPPINGS = {
+  // FIXME add appId
+
   title: ['ds:3', 0, 0, 0],
   description: ['ds:3', 0, 10, 0, 1],
   summary: ['ds:3', 0, 10, 1, 1],
   installs: ['ds:3', 0, 12, 9, 0],
   score: ['ds:10', 0, 0, 1],
   scoreText: ['ds:10', 0, 0, 0],
+  ratings: ['ds:10', 0, 2, 1],
+  reviews: ['ds:10', 0, 3, 1],
+  ratingHistogram: {
+    path: ['ds:10', 0, 1],
+    fun: buildHistogram
+  },
 
   // FIXME should be 0 for free apps
   // TODO add free boolean
@@ -154,17 +162,6 @@ function extractFields (parsedData) {
 //   }
 
 //   const comments = $('.quoted-review').toArray().map((elem) => $(elem).text().trim());
-//   const ratingBox = $('.rating-box');
-//   const reviews = cleanInt(ratingBox.find('span.reviews-num').text());
-
-//   const ratingHistogram = $('.rating-histogram');
-//   const histogram = {
-//     5: cleanInt(ratingHistogram.find('.five .bar-number').text()),
-//     4: cleanInt(ratingHistogram.find('.four .bar-number').text()),
-//     3: cleanInt(ratingHistogram.find('.three .bar-number').text()),
-//     2: cleanInt(ratingHistogram.find('.two .bar-number').text()),
-//     1: cleanInt(ratingHistogram.find('.one .bar-number').text())
-//   };
 
 //   const fields = {
 //     title,
@@ -203,20 +200,11 @@ function extractFields (parsedData) {
 //     preregister
 //   };
 
-//   // replace blank values with undefined
-//   return R.map((field) => field === '' ? undefined : field, fields);
 // }
 // function descriptionText (description) {
 //   // preserve the line breaks when converting to text
 //   const html = '<div>' + description.html().replace(/<\/p>/g, '\n</p>') + '</div>';
 //   return cheerio.load(html)('div').text();
-// }
-
-// function cleanInt (number) {
-//   number = number || '0';
-//   // removes thousands separator
-//   number = number.replace(/\D/g, '');
-//   return parseInt(number);
 // }
 
 // function installNumbers (downloads) {
@@ -237,6 +225,16 @@ function normalizeAndroidVersion (androidVersionText) {
     return number;
   }
   return 'VARY';
+}
+
+function buildHistogram (container) {
+  return {
+    1: container[1][1],
+    2: container[2][1],
+    3: container[3][1],
+    4: container[4][1],
+    5: container[5][1]
+  };
 }
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -59,16 +59,29 @@ function matchScriptData (response) {
     }, {});
 }
 
+// TODO may need to do html to text in some of the fields
+
 const MAPPINGS = {
   title: ['ds:3', 0, 0, 0],
   description: ['ds:3', 0, 10, 0, 1],
+  summary: ['ds:3', 0, 10, 1, 1],
+
   developer: ['ds:3', 0, 12, 5, 1],
   developerId: {
     path: ['ds:3', 0, 12, 5, 5, 4, 2],
     fun: (devUrl) => devUrl.split('id=')[1]
   },
   developerEmail: ['ds:3', 0, 12, 5, 2, 0],
-  developerWebsite: ['ds:3', 0, 12, 5, 3, 5, 2]
+  developerWebsite: ['ds:3', 0, 12, 5, 3, 5, 2],
+
+  genre: ['ds:3', 0, 12, 13, 0, 0],
+  genreId: ['ds:3', 0, 12, 13, 0, 2],
+
+  contentRating: ['ds:3', 0, 12, 4, 0],
+  contentRatingDescription: ['ds:3', 0, 12, 4, 2, 1],
+
+  updated: ['ds:3', 0, 12, 36],
+  recentChanges: ['ds:3', 0, 12, 6, 1]
 };
 
 /*
@@ -91,11 +104,6 @@ function extractFields (parsedData) {
 // FIXME old code kept for reference, remove when done migrating
 
 // function parseFields ($) {
-//   const summary = $('meta[name="description"]').attr('content');
-
-//   const mainGenre = detailsInfo.find('.category').first();
-//   const genreText = mainGenre.text().trim();
-//   const genreId = mainGenre.attr('href').split('/')[4];
 
 //   const familyGenre = detailsInfo.find('.category[href*="FAMILY"]');
 //   let familyGenreText;
@@ -113,10 +121,8 @@ function extractFields (parsedData) {
 //   const additionalInfo = $('.details-section-contents');
 //   const description = additionalInfo.find('div[itemprop=description] div');
 //   const version = additionalInfo.find('div.content[itemprop="softwareVersion"]').text().trim();
-//   const updated = additionalInfo.find('div.content[itemprop="datePublished"]').text().trim();
 //   const androidVersionText = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
 //   const androidVersion = normalizeAndroidVersion(androidVersionText);
-//   const contentRating = additionalInfo.find('div.content[itemprop="contentRating"]').text().trim();
 //   const size = additionalInfo.find('div.content[itemprop="fileSize"]').text().trim();
 
 //   let maxInstalls, minInstalls;
@@ -125,17 +131,6 @@ function extractFields (parsedData) {
 //     const installs = installNumbers(additionalInfo.find('div.content[itemprop="numDownloads"]').text().trim());
 //     minInstalls = cleanInt(installs[0]);
 //     maxInstalls = cleanInt(installs[1]);
-//   }
-
-//   let developerEmail = additionalInfo.find('.dev-link[href^="mailto:"]').attr('href');
-//   if (developerEmail) {
-//     developerEmail = developerEmail.split(':')[1];
-//   }
-
-//   let developerWebsite = additionalInfo.find('.dev-link[href^="http"]').attr('href');
-//   if (developerWebsite) {
-//     // extract clean url wrapped in google url
-//     developerWebsite = url.parse(developerWebsite, true).query.q;
 //   }
 
 //   const developerAddress = additionalInfo.find('.physical-address').text().trim();
@@ -161,7 +156,6 @@ function extractFields (parsedData) {
 //   }
 
 //   const screenshots = $('.thumbnails .screenshot').toArray().map((elem) => $(elem).attr('src'));
-//   const recentChanges = $('.recent-change').toArray().map((elem) => $(elem).text());
 
 //   const fields = {
 //     title,

--- a/lib/app.js
+++ b/lib/app.js
@@ -77,7 +77,7 @@ const MAPPINGS = {
   installs: ['ds:3', 0, 12, 9, 0],
   minInstalls: {
     path: ['ds:3', 0, 12, 9, 0],
-    fun: (text) => parseInt(text.replace(/[^\d]/g, ''))
+    fun: cleanInt
   },
   score: ['ds:10', 0, 0, 1],
   scoreText: ['ds:10', 0, 0, 0],
@@ -90,11 +90,11 @@ const MAPPINGS = {
 
   price: {
     path: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 0],
-    fun: (val) => val / 1000000
+    fun: (val) => val / 1000000 || 0
   },
   free: {
     path: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 0],
-    fun: (val) => val === 0
+    fun: (val) => val === 0 || val === undefined
   },
   currency: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 1],
   priceText: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 2],
@@ -241,6 +241,12 @@ function descriptionText (description) {
 //   throw new Error(`Unable to parse min/max downloads: ${downloads}`);
 // }
 
+function cleanInt (number) {
+  number = number || '0';
+  number = number.replace(/[^\d]/g, ''); // removes thousands separator
+  return parseInt(number);
+}
+
 function normalizeAndroidVersion (androidVersionText) {
   const number = androidVersionText.split(' ')[0];
   if (parseFloat(number)) {
@@ -250,6 +256,9 @@ function normalizeAndroidVersion (androidVersionText) {
 }
 
 function buildHistogram (container) {
+  if (!container) {
+    return { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  }
   return {
     1: container[1][1],
     2: container[2][1],
@@ -260,10 +269,13 @@ function buildHistogram (container) {
 }
 
 function extractComments (comments) {
+  if (!comments) {
+    return [];
+  }
   return R.compose(
     R.take(5),
     R.reject(R.isNil),
-    R.pluck(3))(comments);
+    R.pluck(4))(comments);
 }
 
 module.exports = app;

--- a/lib/app.js
+++ b/lib/app.js
@@ -65,6 +65,8 @@ const MAPPINGS = {
   title: ['ds:3', 0, 0, 0],
   description: ['ds:3', 0, 10, 0, 1],
   summary: ['ds:3', 0, 10, 1, 1],
+  installs: ['ds:3', 0, 12, 9, 0],
+
 
   developer: ['ds:3', 0, 12, 5, 1],
   developerId: {
@@ -76,6 +78,15 @@ const MAPPINGS = {
 
   genre: ['ds:3', 0, 12, 13, 0, 0],
   genreId: ['ds:3', 0, 12, 13, 0, 2],
+
+  icon: ['ds:3', 0, 12, 1, 3, 2],
+  headerImage: ['ds:3', 0, 12, 2, 3, 2],
+  screenshots: {
+    path: ['ds:3', 0, 12, 0],
+    fun: R.map(R.path([3, 2]))
+  },
+  video: ['ds:3', 0, 12, 3, 0, 3, 2],
+  videoImage: ['ds:3', 0, 12, 3, 1, 3, 2],
 
   contentRating: ['ds:3', 0, 12, 4, 0],
   contentRatingDescription: ['ds:3', 0, 12, 4, 2, 1],
@@ -114,12 +125,9 @@ function extractFields (parsedData) {
 //   }
 
 //   const price = detailsInfo.find('meta[itemprop=price]').attr('content');
-//   const icon = detailsInfo.find('img.cover-image').attr('src');
 //   const offersIAP = !!detailsInfo.find('.inapp-msg').length;
 //   const adSupported = !!detailsInfo.find('.ads-supported-label-msg').length;
 
-//   const additionalInfo = $('.details-section-contents');
-//   const description = additionalInfo.find('div[itemprop=description] div');
 //   const version = additionalInfo.find('div.content[itemprop="softwareVersion"]').text().trim();
 //   const androidVersionText = additionalInfo.find('div.content[itemprop="operatingSystems"]').text().trim();
 //   const androidVersion = normalizeAndroidVersion(androidVersionText);
@@ -149,13 +157,6 @@ function extractFields (parsedData) {
 //   };
 //   // for other languages
 //   const score = parseFloat(ratingBox.find('div.score').text().replace(',', '.')) || 0;
-
-//   let video = $('.screenshots span.preview-overlay-container[data-video-url]').attr('data-video-url');
-//   if (video) {
-//     video = video.split('?')[0];
-//   }
-
-//   const screenshots = $('.thumbnails .screenshot').toArray().map((elem) => $(elem).attr('src'));
 
 //   const fields = {
 //     title,

--- a/lib/utils/parseList.js
+++ b/lib/utils/parseList.js
@@ -43,9 +43,6 @@ function parseApp (app) {
 
   // if price string contains numbers, it's not free
   const free = !/\d/.test(price);
-  if (free) {
-    price = '0';
-  }
 
   const scoreText = app.find('div.tiny-star').attr('aria-label');
   let score;
@@ -62,7 +59,7 @@ function parseApp (app) {
     developerId: app.find('a.subtitle').attr('href').split('id=')[1],
     icon: app.find('img.cover-image').attr('data-cover-large'),
     score: score,
-    price: price,
+    priceText: price,
     free: free
   };
 }

--- a/lib/utils/parseList.js
+++ b/lib/utils/parseList.js
@@ -59,6 +59,7 @@ function parseApp (app) {
     developerId: app.find('a.subtitle').attr('href').split('id=')[1],
     icon: app.find('img.cover-image').attr('data-cover-large'),
     score: score,
+    scoreText: scoreText,
     priceText: price,
     free: free
   };

--- a/test/common.js
+++ b/test/common.js
@@ -23,7 +23,11 @@ function assertValidApp (app) {
   }
 
   assert.isBoolean(app.free);
-  assert.isString(app.priceText);
+
+  // FIXME this is only allowed for preregister, check for that when field is available
+  if (app.priceText !== undefined) {
+    assert.isString(app.priceText);
+  }
 
   return app;
 }

--- a/test/common.js
+++ b/test/common.js
@@ -23,7 +23,7 @@ function assertValidApp (app) {
   }
 
   assert.isBoolean(app.free);
-  assert.isString(app.price);
+  assert.isString(app.priceText);
 
   return app;
 }

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -19,12 +19,11 @@ describe('App method', () => {
         assert(app.score <= 5);
 
         assert.isNumber(app.minInstalls);
-        assert.isNumber(app.maxInstalls);
         assert.isNumber(app.reviews);
 
         assert.isString(app.summary);
         assert.isString(app.description);
-        assert.isString(app.descriptionHTML);
+        // assert.isString(app.descriptionHTML);
         assert.isString(app.updated);
         assert.equal(app.genre, 'Action');
         assert.equal(app.genreId, 'GAME_ACTION');
@@ -40,7 +39,7 @@ describe('App method', () => {
 
         assert.equal(app.price, '0');
         assert(app.free === true);
-        assert(app.preregister === false);
+        // assert(app.preregister === false);
 
         assert.equal(app.developer, 'DxCo Games');
         assert.equal(app.developerId, 'DxCo+Games');
@@ -56,8 +55,7 @@ describe('App method', () => {
         assert(app.comments.length);
         app.comments.map(assert.isString);
 
-        assert(app.recentChanges.length);
-        app.recentChanges.map(assert.isString);
+        assert.isString(app.recentChanges);
       });
   });
 
@@ -83,10 +81,9 @@ describe('App method', () => {
         assert.equal(app.title, 'Panda vs Zombies');
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&hl=es&gl=ar');
         assert.isNumber(app.minInstalls);
-        assert.isNumber(app.maxInstalls);
 
         assert.equal(app.androidVersion, '2.3');
-        assert.equal(app.androidVersionText, '2.3 y versiones superiores');
+        assert.equal(app.androidVersionText, '2.3 y versiones posteriores');
       });
   });
 
@@ -97,18 +94,17 @@ describe('App method', () => {
         assert.equal(app.title, 'Panda vs Zombies');
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&hl=fr&gl=fr');
         assert.isNumber(app.minInstalls);
-        assert.isNumber(app.maxInstalls);
 
         assert.equal(app.androidVersion, '2.3');
         assert.equal(app.androidVersionText, '2.3 ou version ultérieure');
       }));
 
-  it('should reject the promise for an invalid appId', (done) =>
+  it('should reject the promise for an invalid appId', () =>
     gplay.app({appId: 'com.dxco.pandavszombiesasdadad'})
-      .then(() => done('should not resolve'))
-      .catch((err) => {
-        assert.equal(err.message, 'App not found (404)');
-        done();
-      })
-      .catch(done));
+     .then(() => {
+       throw Error('should not resolve');
+     })
+     .catch((err) => {
+       assert.equal(err.message, 'App not found (404)');
+     }));
 });

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -37,7 +37,8 @@ describe('App method', () => {
         assert.equal(app.androidVersion, '2.3');
         assert.equal(app.androidVersionText, '2.3 and up');
 
-        assert.equal(app.price, '0');
+        assert.equal(app.priceText, 'Free');
+        assert.equal(app.price, 0);
         assert(app.free === true);
         // assert(app.preregister === false);
 

--- a/test/lib.developer.js
+++ b/test/lib.developer.js
@@ -15,8 +15,8 @@ describe('Developer method', () => {
   it('should fetch several pages of distinct apps for the developer', () =>
      gplay.developer({devId: 'Google LLC', num: 100})
      .then((apps) => {
-       assert(apps.length === 100, 'should return as many apps as requested');
-       assert(R.uniq(apps).length === 100, 'should return distinct apps');
+       assert.equal(100, apps.length, 'should return as many apps as requested');
+       assert.equal(100, R.uniq(apps).length, 'should return distinct apps');
      }));
 
   it('should not throw an error if too many apps requested', () =>

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -74,11 +74,10 @@ describe('List method', () => {
     .then((apps) => apps.map(assertValidApp))
     .then((apps) => apps.map((app) => {
       assert.isNumber(app.minInstalls);
-      assert.isNumber(app.maxInstalls);
       assert.isNumber(app.reviews);
 
       assert.isString(app.description);
-      assert.isString(app.descriptionHTML);
+      // assert.isString(app.descriptionHTML);
       assert.isString(app.updated);
 
       assert.equal(app.genre, 'Action');
@@ -90,7 +89,7 @@ describe('List method', () => {
       assert.isString(app.androidVersion);
       assert.isString(app.contentRating);
 
-      assert.equal(app.price, '0');
+      assert.equal(app.priceText, 'Free');
       assert(app.free);
 
       assert.isString(app.developer);

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -77,7 +77,7 @@ describe('List method', () => {
       assert.isNumber(app.reviews);
 
       assert.isString(app.description);
-      // assert.isString(app.descriptionHTML);
+      assert.isString(app.descriptionHTML);
       assert.isString(app.updated);
 
       assert.equal(app.genre, 'Action');

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -104,4 +104,25 @@ describe('List method', () => {
       app.comments.map(assert.isString);
     }));
   });
+
+  // fetch last page of new paid apps, which have a bigger chance of including
+  // results with no downloads (less fields, prone to failures)
+  it('It should not fail with apps with no downloads', () =>
+     gplay.list({
+       category: gplay.category.GAME_ACTION,
+       collection: gplay.collection.NEW_PAID,
+       num: 20,
+       start: 500
+     })
+     .then((apps) => apps.map(assertValidApp)));
+
+  it('It should not fail with apps with no downloads and fullDetail', () =>
+     gplay.list({
+       category: gplay.category.GAME_ACTION,
+       collection: gplay.collection.NEW_PAID,
+       num: 10,
+       start: 500,
+       fullDetail: true
+     })
+     .then((apps) => apps.map(assertValidApp)));
 });

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -34,16 +34,16 @@ describe('Search method', () => {
      .then((apps) => apps.map(assertValidApp)));
 
   it('should fetch multiple pages of distinct results', () =>
-     gplay.search({term: 'panda', num: 155})
+     gplay.search({term: 'panda', num: 55})
      .then((apps) => {
-       assert(apps.length === 155, 'should return as many apps as requested');
-       assert(R.uniq(apps).length === 155, 'should return distinct apps');
+       assert.equal(55, apps.length, 'should return as many apps as requested');
+       assert.equal(55, R.uniq(apps).length, 'should return distinct apps');
      }));
 
   it('should fetch multiple pages of when not starting from cluster of subsections', () =>
      gplay.search({term: 'clash of clans', num: 65})
      .then((apps) => {
-       assert(apps.length === 65, 'should return as many apps as requested');
-       assert(R.uniq(apps).length === 65, 'should return distinct apps');
+       assert.equal(65, apps.length, 'should return as many apps as requested');
+       assert.equal(65, R.uniq(apps).length, 'should return distinct apps');
      }));
 });

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -23,6 +23,16 @@ describe('Search method', () => {
     });
   });
 
+  // preregister tend to have some fields missing, increasing chances of failure
+  // by searching "preregister" we have more chances of getting some in the results
+  it('should search for pre register', () =>
+     gplay.search({term: 'preregister', num: 10})
+     .then((apps) => apps.map(assertValidApp)));
+
+  it('should search for pre register with fullDetail', () =>
+     gplay.search({term: 'preregister', num: 10, fullDetail: true})
+     .then((apps) => apps.map(assertValidApp)));
+
   it('should fetch multiple pages of distinct results', () =>
      gplay.search({term: 'panda', num: 155})
      .then((apps) => {


### PR DESCRIPTION
This fixes #192 by extracting the app data from the js code in the script tags of the app detail html.

All the script data is added to a map object (with keys like `ds:13`, `ds:8`, etc). A `MAPPINGS` constant declares how to extract each field from that parsed object.

Only added the first couple of fields so far, feel free to PR this branch adding new fields to `MAPPINGS`.

- [x] tests passing
- [x] migrate important fields
- [x] add a test for preregister apps (search "pre register"+ fullDetail)
- [x] add a test for apps with no downloads (list last page of top new paid + fullDetail)
- [x] create issues for missing fields
- [x] update readme to reflect new fields (both app.js and list.js)
