### PR TITLE
Added preregister field and fixed some bugs

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -77,7 +77,7 @@ const MAPPINGS = {
   installs: ['ds:3', 0, 12, 9, 0],
   minInstalls: {
     path: ['ds:3', 0, 12, 9, 0],
-    fun: (text) => parseInt(text.replace(/[^\d]/g, ''))
+    fun: cleanInt
   },
   score: ['ds:10', 0, 0, 1],
   scoreText: ['ds:10', 0, 0, 0],
@@ -87,14 +87,18 @@ const MAPPINGS = {
     path: ['ds:10', 0, 1],
     fun: buildHistogram
   },
+  preregister: {
+    path: ['ds:10', 0, 1], // histogramContainer path
+    fun: R.complement(Boolean) // if the app does not contain the histogram it is a preregister app
+  },
 
   price: {
     path: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 0],
-    fun: (val) => val / 1000000
+    fun: (val) => val / 1000000 || 0
   },
   free: {
     path: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 0],
-    fun: (val) => val === 0
+    fun: (val) => val === 0 || val === undefined
   },
   currency: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 1],
   priceText: ['ds:8', 0, 2, 0, 0, 0, 1, 0, 2],
@@ -241,6 +245,12 @@ function descriptionText (description) {
 //   throw new Error(`Unable to parse min/max downloads: ${downloads}`);
 // }
 
+function cleanInt (number) {
+  number = number || '0';
+  number = number.replace(/[^\d]/g, ''); // removes thousands separator
+  return parseInt(number);
+}
+
 function normalizeAndroidVersion (androidVersionText) {
   const number = androidVersionText.split(' ')[0];
   if (parseFloat(number)) {
@@ -250,6 +260,9 @@ function normalizeAndroidVersion (androidVersionText) {
 }
 
 function buildHistogram (container) {
+  if (!container) {
+    return { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  }
   return {
     1: container[1][1],
     2: container[2][1],
@@ -260,10 +273,13 @@ function buildHistogram (container) {
 }
 
 function extractComments (comments) {
+  if (!comments) {
+    return [];
+  }
   return R.compose(
     R.take(5),
     R.reject(R.isNil),
-    R.pluck(3))(comments);
+    R.pluck(4))(comments);
 }
 
 module.exports = app;

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -43,7 +43,7 @@ describe('App method', () => {
         assert.equal(app.price, 0);
         assert(app.free === true);
         assert.equal(app.offersIAP, false);
-        // assert(app.preregister === false);
+        assert(app.preregister === false);
 
         assert.equal(app.developer, 'DxCo Games');
         assert.equal(app.developerId, 'DxCo+Games');


### PR DESCRIPTION
Almost all bugs were happening when the app was a "`preregistered`" app, therefore there were some `undefined` values not properly handled. (When the `preregister` is `true`, the `price`, `comments` , `minInstall` and `histogram` values are undefined)

This `appId` can be used to test the cases described above: `com.gamedevltd.destinywarfare`