### PR TITLE
add appId to permissioins response

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,14 +354,16 @@ gplay.permissions({appId: "com.dxco.pandavszombies"}).then(console.log);
 
 Results:
 ```javascript
-[ { permission: 'modify or delete the contents of your USB storage',
-    description: 'Allows the app to write to the USB storage.' },
-  { permission: 'read the contents of your USB storage',
-    description: 'Allows the app to read the contents of your USB storage.' },
-  { permission: 'full network access',
-    description: 'Allows the app to create network sockets and use custom network protocols. The browser and other applications provide means to send data to the internet, so this permission is not required to send data to the internet.' },
-  { permission: 'view network connections',
-    description: 'Allows the app to view information about network connections such as which networks exist and are connected.' } ]
+{ appId: 'com.dxco.pandavszombies',
+  permissions:
+  [ { permission: 'modify or delete the contents of your USB storage',
+      description: 'Allows the app to write to the USB storage.' },
+    { permission: 'read the contents of your USB storage',
+      description: 'Allows the app to read the contents of your USB storage.' },
+    { permission: 'full network access',
+      description: 'Allows the app to create network sockets and use custom network protocols. The browser and other applications provide means to send data to the internet, so this permission is not required to send data to the internet.' },
+    { permission: 'view network connections',
+      description: 'Allows the app to view information about network connections such as which networks exist and are connected.' } ] }
 ```
 
 ### categories

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -44,12 +44,20 @@ function permissions (opts) {
       res = JSON.parse(res);
       // grab the array that contains all the permission definitions
       // this doesnt look too solid but well
-      return res[0][2][0][65]['42656262'][1] || [];
+      return {
+        appId: res[0][2][0][0],
+        items: res[0][2][0][65]['42656262'][1] || []
+      };
     })
-    .then(parsePermissions)
+    .then(function (res) {
+      return {
+        appId: res.appId,
+        permissions: parsePermissions(res.items)
+      }
+    })
     .then((perms) => {
       if (opts.short) {
-        return R.pluck('permission', perms);
+        return R.pluck('permission', perms.permissions);
       }
       return perms;
     })


### PR DESCRIPTION
When executing the permissions method consecutively for multiple appid, I didn't know the result for which appid.
So I added appId to the permissions method.