### PR TITLE
Default language fix

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -9,18 +9,22 @@ const c = require('./constants');
 function reviews (opts) {
   return new Promise(function (resolve, reject) {
     validate(opts);
+    const form = {
+      pageNum: opts.page || 0,
+      id: opts.appId || opts.id,
+      reviewSortOrder: opts.sort || c.sort.NEWEST,
+      reviewType: 0,
+      xhr: 1
+    };
+
+    if(opts.lang) {
+      form.hl = opts.lang
+    }
 
     const options = Object.assign({
       method: 'POST',
       uri: 'https://play.google.com/store/getreviews',
-      form: {
-        pageNum: opts.page || 0,
-        id: opts.appId || opts.id,
-        reviewSortOrder: opts.sort || c.sort.NEWEST,
-        hl: opts.lang || 'en',
-        reviewType: 0,
-        xhr: 1
-      },
+      form: form,
       json: true,
       followAllRedirects: true
     }, opts.requestOptions);

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -18,7 +18,7 @@ function reviews (opts) {
     };
 
     if(opts.lang) {
-      form.hl = opts.lang
+      form.hl = opts.lang;
     }
 
     const options = Object.assign({


### PR DESCRIPTION
Google play can return all reviews if hl option not set. No need to have default 'en' lang.