### PR TITLE
fix developer id

### DIFF
--- a/lib/utils/appList.js
+++ b/lib/utils/appList.js
@@ -32,7 +32,7 @@ const MAPPINGS = {
 };
 
 function extaractDeveloperId (link) {
-  return querystring.parse(link.split('?')[1]).id;
+  return link.split('?id=')[1];
 }
 
 /*


### PR DESCRIPTION
Developer id is returning as Khan Academy for the search term khan instead of Khan+Academy
This pull request fixes the developer id parsing