### PR TITLE
fixes for gplay store after 2019-09-01 updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Options:
 
 * `appId`: Unique application id for Google Play. (e.g. id=com.mojang.minecraftpe maps to Minecraft: Pocket Edition game).
 * `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the reviews.
+* `country` (optional, defaults to `'us'`): the two letter country code in which to fetch the reviews.
 * `sort` (optional, defaults to `sort.NEWEST`): The way the reviews are going to be sorted. Accepted values are: `sort.NEWEST`, `sort.RATING` and `sort.HELPFULNESS`.
 * `num` (optional, defaults to 100): Quantity of reviews to be captured.
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Options:
 * `appId`: Unique application id for Google Play. (e.g. id=com.mojang.minecraftpe maps to Minecraft: Pocket Edition game).
 * `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the reviews.
 * `sort` (optional, defaults to `sort.NEWEST`): The way the reviews are going to be sorted. Accepted values are: `sort.NEWEST`, `sort.RATING` and `sort.HELPFULNESS`.
-* `page` (optional, defaults to 0): Number of page that contains reviews. Every page has 40 reviews at most.
+* `num` (optional, defaults to 100): Quantity of reviews to be captured.
 
 Example:
 
@@ -275,8 +275,8 @@ var gplay = require('google-play-scraper');
 
 gplay.reviews({
   appId: 'com.mojang.minecraftpe',
-  page: 0,
   sort: gplay.sort.RATING
+  num: 500
 }).then(console.log, console.log);
 ```
 
@@ -290,7 +290,7 @@ Results:
     score: 5,
     scoreText: '5',
     url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRWZaVHVZZ081NlNsRW9TV0hJeklGSTBvYTBTUlFQUUJIZThBSGJDX2s1Y1o0ZXRCbUtLZmgzTE1PMUttRmpRSS1YcFgxRmx1ZXNtVzlVS0Zz'
-    title: 'I LOVE IT',
+    title: 'I LOVE IT', //GOOGLE DO NOT RETURN THE TITLE ANYMORE
     text: 'It has skins and snowballs everything I wanted its so cool I love it!!!!!!!!',
     replyDate: 'June 9, 2015',
     replyText: 'thanks for playing Panda vs Zombies!' },
@@ -301,10 +301,12 @@ Results:
     url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRmFHdlBFS2pGS2JVYW5Dd3kxTm1qUzRxQlYyc3Z4ZE9CYXRuc0hkclV3a09hbEFkOVdoWmw3eFN5VjF4cDJPLTg5TW5ZUjl1Zm9HOWc5NGtr',
     score: 5,
     scoreText: '5',
-    title: 'CAN NEVER WAIT TILL NEW UPDATE',
+    title: 'CAN NEVER WAIT TILL NEW UPDATE', //GOOGLE DO NOT RETURN THE TITLE ANYMORE
     text: 'Love it but needs to pay more attention to pocket edition',
     replyDate: undefined,
-    replyText: undefined } ]
+    replyText: undefined,
+    version: '1.0.2',
+    thumbsUp: 29 } ]
 ```
 
 ### similar
@@ -342,8 +344,7 @@ Returns the list of permissions an app has access to.
 
 * `appId`: the Google Play id of the application to get permissions for.
 * `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the permissions.
-* `short` (optional, defaults to `false`): if `true`, the permission names will be returned instead of
-permission/description objects.
+* `short` (optional, defaults to `false`): if `true`, the permission names will be returned instead of permission/description objects.
 
 Example:
 
@@ -356,13 +357,17 @@ gplay.permissions({appId: "com.dxco.pandavszombies"}).then(console.log);
 Results:
 ```javascript
 [ { permission: 'modify or delete the contents of your USB storage',
-    description: 'Allows the app to write to the USB storage.' },
+    description: 'Allows the app to write to the USB storage.',
+    type: 'Storage' },
   { permission: 'read the contents of your USB storage',
-    description: 'Allows the app to read the contents of your USB storage.' },
+    description: 'Allows the app to read the contents of your USB storage.',
+    type: 'Storage' },
   { permission: 'full network access',
-    description: 'Allows the app to create network sockets and use custom network protocols. The browser and other applications provide means to send data to the internet, so this permission is not required to send data to the internet.' },
+    description: 'Allows the app to create network sockets and use custom network protocols. The browser and other applications provide means to send data to the internet, so this permission is not required to send data to the internet.',
+    type: 'Photos/Media/Files' },
   { permission: 'view network connections',
-    description: 'Allows the app to view information about network connections such as which networks exist and are connected.' } ]
+    description: 'Allows the app to view information about network connections such as which networks exist and are connected.',
+    type: '' } ]
 ```
 
 ### categories

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const parseList = R.partial(getParseList, [appMethod]);
 
 const methods = {
   app: appMethod,
-  list: R.partial(require('./lib/list'), [parseList]),
+  list: require('./lib/list'),
   search: R.partial(require('./lib/search'), [parseList]),
   suggest: require('./lib/suggest'),
   developer: R.partial(require('./lib/developer'), [parseList]),

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -4,7 +4,7 @@ const request = require('./utils/request');
 const cheerio = require('cheerio');
 
 const PLAYSTORE_URL = 'https://play.google.com/store/apps';
-const CATEGORY_URL_PREFIX = 'https://play.google.com/store/apps/category/';
+const CATEGORY_URL_PREFIX = '/store/apps/category/';
 
 function categories (opts) {
   opts = Object.assign({}, opts);
@@ -26,6 +26,7 @@ function categories (opts) {
 }
 
 function extractCategories ($) {
+  console.log($('ul li a').toArray );
   const categoryIds = $('ul li a')
     .toArray()
     .map((el) => $(el).attr('href'))

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -26,7 +26,6 @@ function categories (opts) {
 }
 
 function extractCategories ($) {
-  console.log($('ul li a').toArray );
   const categoryIds = $('ul li a')
     .toArray()
     .map((el) => $(el).attr('href'))

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -72,9 +72,9 @@ module.exports.collection = {
 };
 
 module.exports.sort = {
-  NEWEST: 0,
-  RATING: 1,
-  HELPFULNESS: 2
+  NEWEST: 2,
+  RATING: 3,
+  HELPFULNESS: 1
 };
 
 module.exports.age = {

--- a/lib/list.js
+++ b/lib/list.js
@@ -4,8 +4,26 @@ const request = require('./utils/request');
 const cheerio = require('cheerio');
 const R = require('ramda');
 const c = require('./constants');
+const scriptData = require('./utils/scriptData');
+const appList = require('./utils/appList');
+
+const BASE_URL = 'https://play.google.com';
+const body = 'f.req=%5B%5B%5B%22qnKhOb%22%2C%22%5B%5Bnull%2C%5B%5B10%2C%5B10%2C50%5D%5D%2Ctrue%2Cnull%2C%5B96%2C27%2C4%2C8%2C57%2C30%2C110%2C79%2C11%2C16%2C49%2C1%2C3%2C9%2C12%2C104%2C55%2C56%2C51%2C10%2C34%2C77%5D%5D%2Cnull%2C%5C%22%token%%5C%22%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D';
+const INITIAL_MAPPINGS = {
+  apps: ['ds:3', 0, 1, 0, 0, 0],
+  token: ['ds:3', 0, 1, 0, 0, 7, 1]
+};
+
+const REQUEST_MAPPINGS = {
+  apps: [0, 0, 0],
+  token: [0, 0, 7, 1]
+};
 
 function list (getParseList, opts) {
+  if (opts.category) {
+    return listCategoryApps({}, opts);
+  }
+
   return new Promise(function (resolve, reject) {
     opts = R.clone(opts || {});
     validate(opts);
@@ -55,20 +73,114 @@ function validate (opts) {
 }
 
 function buildUrl (opts) {
-  let url = 'https://play.google.com/store/apps';
+  let url = `${BASE_URL}/store/apps`;
 
-  if (opts.category) {
-    url += `/category/${opts.category}`;
-  }
+  url += (opts.category)
+    ? `/top/category/${opts.category}`
+    : `/collection/${opts.collection}`;
 
-  url += `/collection/${opts.collection}`;
   url += `?hl=${opts.lang}&gl=${opts.country}&num=${opts.num}`;
 
   if (opts.age) {
     url += `&age=${opts.age}`;
   }
 
+  console.log(url);
+
   return url;
+}
+
+function getParsedCluster (object, opts) {
+  const collections = {
+    [c.collection.TOP_FREE]: 0,
+    [c.collection.GROSSING]: 1,
+    [c.collection.TRENDING]: 2,
+    [c.collection.TOP_PAID]: 3
+  };
+
+  const selectedCollection = collections[opts.collection] || collections[c.collection.TOP_FREE];
+
+  const CLUSTER_MAPPINGS = ['ds:3', 0, 1, selectedCollection, 0, 3, 4, 2];
+
+  return R.path(CLUSTER_MAPPINGS, object);
+}
+
+function processAndRecur (html, opts, savedApps, mappings) {
+  if (R.is(String, html)) {
+    html = scriptData.parse(html);
+  }
+
+  const apps = appList.extract(mappings.apps, html);
+  const token = R.path(mappings.token, html);
+
+  return checkFinished(opts, [...savedApps, ...apps], token);
+}
+
+function checkFinished (opts, savedApps, nextToken) {
+  if (savedApps.length >= opts.num || !nextToken) {
+    return savedApps.slice(0, opts.num);
+  }
+
+  const requestOptions = Object.assign({
+    url: `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=en&gl=us&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`,
+    method: 'POST',
+    body: body.replace('%token%', nextToken),
+    followAllRedirects: true,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    }
+  }, opts.requestOptions);
+
+  return request(requestOptions, opts.throttle)
+    .then((html) => {
+      const input = JSON.parse(html.substring(5));
+      const data = JSON.parse(input[0][2]);
+
+      return processAndRecur(data, opts, savedApps, REQUEST_MAPPINGS);
+    });
+}
+
+function getParsedApps (object, opts) {
+  return processAndRecur(object, opts, [], INITIAL_MAPPINGS);
+}
+
+function processCluster (clusterUrl, opts) {
+  const clusterUrlToProcess = `${BASE_URL}${clusterUrl}&hl=${opts.lang}&gl=${opts.country}&num=${opts.num}`;
+
+  const options = Object.assign({
+    url: clusterUrlToProcess,
+    method: 'GET',
+    followAllRedirects: true
+  });
+
+  request(options, opts.throttle)
+    .then(scriptData.parse)
+    .then(object => getParsedApps(object, opts))
+    .then((apps) => console.log(apps.length))
+    .catch(console.log);
+}
+
+function listCategoryApps (func, opts) {
+  return new Promise(function (resolve, reject) {
+    opts = R.clone(opts || {});
+    validate(opts);
+
+    const options = Object.assign({
+      url: buildUrl(opts),
+      method: 'GET',
+      followAllRedirects: true
+    }, opts.requestOptions);
+
+    request(options, opts.throttle)
+      .then(scriptData.parse)
+      .then(parsedObject => getParsedCluster(parsedObject, opts))
+      .then(clusterUrl => processCluster(clusterUrl, opts))
+      .then(resolve)
+      .catch(err => {
+        console.log(err);
+        reject(err);
+      });
+  });
 }
 
 module.exports = list;

--- a/lib/list.js
+++ b/lib/list.js
@@ -2,32 +2,26 @@
 
 const debug = require('debug')('google-play-scraper:list');
 const request = require('./utils/request');
-const cheerio = require('cheerio');
 const R = require('ramda');
 const c = require('./constants');
 const scriptData = require('./utils/scriptData');
 const parseCategoryApps = require('./utils/parseCategoryApps');
 const { BASE_URL } = require('./utils/configurations');
 
-function list (getParseList, opts) {
-  if (opts.category) {
-    return listCategoryApps(opts);
-  }
-
+function list (opts) {
   return new Promise(function (resolve, reject) {
     opts = R.clone(opts || {});
     validate(opts);
 
     const options = Object.assign({
       url: buildUrl(opts),
-      method: 'POST',
-      form: opts.form,
+      method: 'GET',
       followAllRedirects: true
     }, opts.requestOptions);
 
     request(options, opts.throttle)
-      .then(cheerio.load)
-      .then(getParseList(opts))
+      .then(scriptData.parse)
+      .then(parsedObject => parseCategoryApps(parsedObject, opts))
       .then(resolve)
       .catch(reject);
   });
@@ -78,25 +72,6 @@ function buildUrl (opts) {
   debug('Initial Request URL: %s', url);
 
   return url;
-}
-
-function listCategoryApps (opts) {
-  return new Promise(function (resolve, reject) {
-    opts = R.clone(opts || {});
-    validate(opts);
-
-    const options = Object.assign({
-      url: buildUrl(opts),
-      method: 'GET',
-      followAllRedirects: true
-    }, opts.requestOptions);
-
-    request(options, opts.throttle)
-      .then(scriptData.parse)
-      .then(parsedObject => parseCategoryApps(parsedObject, opts))
-      .then(resolve)
-      .catch(reject);
-  });
 }
 
 module.exports = list;

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,27 +1,17 @@
 'use strict';
 
+const debug = require('debug')('google-play-scraper:list');
 const request = require('./utils/request');
 const cheerio = require('cheerio');
 const R = require('ramda');
 const c = require('./constants');
 const scriptData = require('./utils/scriptData');
-const appList = require('./utils/appList');
-
-const BASE_URL = 'https://play.google.com';
-const body = 'f.req=%5B%5B%5B%22qnKhOb%22%2C%22%5B%5Bnull%2C%5B%5B10%2C%5B10%2C50%5D%5D%2Ctrue%2Cnull%2C%5B96%2C27%2C4%2C8%2C57%2C30%2C110%2C79%2C11%2C16%2C49%2C1%2C3%2C9%2C12%2C104%2C55%2C56%2C51%2C10%2C34%2C77%5D%5D%2Cnull%2C%5C%22%token%%5C%22%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D';
-const INITIAL_MAPPINGS = {
-  apps: ['ds:3', 0, 1, 0, 0, 0],
-  token: ['ds:3', 0, 1, 0, 0, 7, 1]
-};
-
-const REQUEST_MAPPINGS = {
-  apps: [0, 0, 0],
-  token: [0, 0, 7, 1]
-};
+const parseCategoryApps = require('./utils/parseCategoryApps');
+const { BASE_URL } = require('./utils/configurations');
 
 function list (getParseList, opts) {
   if (opts.category) {
-    return listCategoryApps({}, opts);
+    return listCategoryApps(opts);
   }
 
   return new Promise(function (resolve, reject) {
@@ -58,9 +48,8 @@ function validate (opts) {
   }
 
   opts.num = opts.num || 60;
-  const maxApps = opts.category ? 195 : 120;
-  if (opts.num > maxApps) {
-    throw Error(`Cannot retrieve more than ${maxApps} apps at a time`);
+  if (opts.num > 120) {
+    throw Error(`Cannot retrieve more than 120 apps at a time`);
   }
 
   opts.start = opts.start || 0;
@@ -77,90 +66,21 @@ function buildUrl (opts) {
   let url = `${BASE_URL}/store/apps`;
 
   url += (opts.category)
-    ? `/top/category/${opts.category}`
-    : `/collection/${opts.collection}`;
+    ? `/top/category/${opts.category}?`
+    : `/collection/${opts.collection}?num=${opts.num}&`;
 
-  url += `?hl=${opts.lang}&gl=${opts.country}&num=${opts.num}`;
+  url += `hl=${opts.lang}&gl=${opts.country}`;
 
   if (opts.age) {
     url += `&age=${opts.age}`;
   }
 
-  console.log(url);
+  debug('Initial Request URL: %s', url);
 
   return url;
 }
 
-function getParsedCluster (object, opts) {
-  const collections = {
-    [c.collection.TOP_FREE]: 0,
-    [c.collection.GROSSING]: 1,
-    [c.collection.TRENDING]: 2,
-    [c.collection.TOP_PAID]: 3
-  };
-
-  const selectedCollection = collections[opts.collection] || collections[c.collection.TOP_FREE];
-
-  const CLUSTER_MAPPINGS = ['ds:3', 0, 1, selectedCollection, 0, 3, 4, 2];
-
-  return R.path(CLUSTER_MAPPINGS, object);
-}
-
-function processAndRecur (html, opts, savedApps, mappings) {
-  if (R.is(String, html)) {
-    html = scriptData.parse(html);
-  }
-
-  const apps = appList.extract(mappings.apps, html);
-  const token = R.path(mappings.token, html);
-
-  return checkFinished(opts, [...savedApps, ...apps], token);
-}
-
-function checkFinished (opts, savedApps, nextToken) {
-  if (savedApps.length >= opts.num || !nextToken) {
-    return savedApps.slice(0, opts.num);
-  }
-
-  const requestOptions = Object.assign({
-    url: `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=en&gl=us&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`,
-    method: 'POST',
-    body: body.replace('%token%', nextToken),
-    followAllRedirects: true,
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
-    }
-  }, opts.requestOptions);
-
-  return request(requestOptions, opts.throttle)
-    .then((html) => {
-      const input = JSON.parse(html.substring(5));
-      const data = JSON.parse(input[0][2]);
-
-      return processAndRecur(data, opts, savedApps, REQUEST_MAPPINGS);
-    });
-}
-
-function getParsedApps (object, opts) {
-  return processAndRecur(object, opts, [], INITIAL_MAPPINGS);
-}
-
-function processCluster (clusterUrl, opts) {
-  const clusterUrlToProcess = `${BASE_URL}${clusterUrl}&hl=${opts.lang}&gl=${opts.country}&num=${opts.num}`;
-
-  const options = Object.assign({
-    url: clusterUrlToProcess,
-    method: 'GET',
-    followAllRedirects: true
-  });
-
-  return request(options, opts.throttle)
-    .then(scriptData.parse)
-    .then(object => getParsedApps(object, opts))
-    .catch(console.log);
-}
-
-function listCategoryApps (func, opts) {
+function listCategoryApps (opts) {
   return new Promise(function (resolve, reject) {
     opts = R.clone(opts || {});
 
@@ -172,13 +92,9 @@ function listCategoryApps (func, opts) {
 
     request(options, opts.throttle)
       .then(scriptData.parse)
-      .then(parsedObject => getParsedCluster(parsedObject, opts))
-      .then(clusterUrl => processCluster(clusterUrl, opts))
+      .then(parsedObject => parseCategoryApps(parsedObject, opts))
       .then(resolve)
-      .catch(err => {
-        console.log(err);
-        reject(err);
-      });
+      .catch(reject);
   });
 }
 

--- a/lib/list.js
+++ b/lib/list.js
@@ -83,6 +83,7 @@ function buildUrl (opts) {
 function listCategoryApps (opts) {
   return new Promise(function (resolve, reject) {
     opts = R.clone(opts || {});
+    validate(opts);
 
     const options = Object.assign({
       url: buildUrl(opts),

--- a/lib/list.js
+++ b/lib/list.js
@@ -41,11 +41,6 @@ function validate (opts) {
     throw Error(`Invalid age range ${opts.age}`);
   }
 
-  opts.num = opts.num || 60;
-  if (opts.num > 120) {
-    throw Error(`Cannot retrieve more than 120 apps at a time`);
-  }
-
   opts.start = opts.start || 0;
   if (opts.start > 500) {
     throw Error('The maximum starting index is 500');

--- a/lib/list.js
+++ b/lib/list.js
@@ -153,7 +153,7 @@ function processCluster (clusterUrl, opts) {
     followAllRedirects: true
   });
 
-  request(options, opts.throttle)
+  return request(options, opts.throttle)
     .then(scriptData.parse)
     .then(object => getParsedApps(object, opts))
     .catch(console.log);

--- a/lib/list.js
+++ b/lib/list.js
@@ -58,8 +58,9 @@ function validate (opts) {
   }
 
   opts.num = opts.num || 60;
-  if (opts.num > 120) {
-    throw Error('Cannot retrieve more than 120 apps at a time');
+  const maxApps = opts.category ? 195 : 120;
+  if (opts.num > maxApps) {
+    throw Error(`Cannot retrieve more than ${maxApps} apps at a time`);
   }
 
   opts.start = opts.start || 0;
@@ -162,7 +163,6 @@ function processCluster (clusterUrl, opts) {
 function listCategoryApps (func, opts) {
   return new Promise(function (resolve, reject) {
     opts = R.clone(opts || {});
-    validate(opts);
 
     const options = Object.assign({
       url: buildUrl(opts),

--- a/lib/list.js
+++ b/lib/list.js
@@ -156,7 +156,6 @@ function processCluster (clusterUrl, opts) {
   request(options, opts.throttle)
     .then(scriptData.parse)
     .then(object => getParsedApps(object, opts))
-    .then((apps) => console.log(apps.length))
     .catch(console.log);
 }
 

--- a/lib/mappers/request.js
+++ b/lib/mappers/request.js
@@ -1,11 +1,18 @@
+'use strict';
+
 const INITIAL_MAPPINGS = {
   apps: ['ds:3', 0, 1, 0, 0, 0],
-  token: ['ds:3', 0, 1, 0, 0, 7, 1]
+  token: ['ds:3', 0, 1, 0, 0, 7, 1],
+  categories: ['ds:3', 0, 1],
+  reviews: ['ds:15', 0],
+  reviewsToken: ['ds:15', 1, 1]
 };
 
 const REQUEST_MAPPINGS = {
   apps: [0, 0, 0],
-  token: [0, 0, 7, 1]
+  token: [0, 0, 7, 1],
+  reviews: [0],
+  reviewsToken: [1, 1]
 };
 
 module.exports = {

--- a/lib/mappers/request.js
+++ b/lib/mappers/request.js
@@ -1,0 +1,14 @@
+const INITIAL_MAPPINGS = {
+  apps: ['ds:3', 0, 1, 0, 0, 0],
+  token: ['ds:3', 0, 1, 0, 0, 7, 1]
+};
+
+const REQUEST_MAPPINGS = {
+  apps: [0, 0, 0],
+  token: [0, 0, 7, 1]
+};
+
+module.exports = {
+  INITIAL_MAPPINGS,
+  REQUEST_MAPPINGS
+};

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -8,6 +8,8 @@ function permissions (opts) {
       throw Error('appId missing');
     }
 
+    opts.lang = opts.lang || 'en';
+
     processPermissions(opts)
       .then(resolve)
       .then(reject);

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -1,24 +1,6 @@
 'use strict';
 
-const request = require('./utils/request');
-const R = require('ramda');
-
-const isPermission = (item) => R.is(Array, item) && item.length === 3 && R.is(String, item[0]) && R.is(String, item[1]);
-
-function parsePermissions (items) {
-  return items.reduce((results, item) => {
-    if (isPermission(item)) {
-      return R.append({
-        permission: item[0],
-        description: item[1]
-      }, results);
-    }
-    if (R.is(Array, item)) {
-      return results.concat(parsePermissions(item));
-    }
-    return results;
-  }, []);
-}
+const { processPermissions } = require('./requesters/permissionMappedRequests');
 
 function permissions (opts) {
   return new Promise(function (resolve, reject) {
@@ -26,35 +8,9 @@ function permissions (opts) {
       throw Error('appId missing');
     }
 
-    const options = Object.assign({
-      method: 'POST',
-      url: 'https://play.google.com/store/xhr/getdoc?authuser=0',
-      form: {
-        ids: opts.appId,
-        hl: opts.lang || 'en',
-        xhr: 1
-      },
-      followAllRedirects: true
-    }, opts.requestOptions);
-
-    request(options, opts.throttle)
-      .then(function (res) {
-      // remove leading garbage and insert nulls in missing array elements
-        res = res.slice(5).replace(/,,/g, ',null,').replace(/,,/g, ',null,').replace(/\[,/g, '[null,');
-        res = JSON.parse(res);
-        // grab the array that contains all the permission definitions
-        // this doesnt look too solid but well
-        return res[0][2][0][65]['42656262'][1] || [];
-      })
-      .then(parsePermissions)
-      .then((perms) => {
-        if (opts.short) {
-          return R.pluck('permission', perms);
-        }
-        return perms;
-      })
+    processPermissions(opts)
       .then(resolve)
-      .catch(reject);
+      .then(reject);
   });
 }
 

--- a/lib/requesters/appsMappedRequests.js
+++ b/lib/requesters/appsMappedRequests.js
@@ -1,12 +1,12 @@
 'use strict';
 
-const debug = require('debug')('google-play-scraper:dsMappedRequests');
-const request = require('./request');
+const debug = require('debug')('google-play-scraper:appsMappedRequests');
+const request = require('../utils/request');
 const R = require('ramda');
-const scriptData = require('./scriptData');
-const appList = require('./appList');
+const scriptData = require('../utils/scriptData');
+const appList = require('../utils/appList');
 const { REQUEST_MAPPINGS } = require('../mappers/request');
-const { BASE_URL } = require('./configurations');
+const { BASE_URL } = require('../utils/configurations');
 const appDetails = require('../app');
 
 function getBodyForRequests ({

--- a/lib/requesters/appsMappedRequests.js
+++ b/lib/requesters/appsMappedRequests.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const debug = require('debug')('google-play-scraper:appsMappedRequests');
-const request = require('../utils/request');
 const R = require('ramda');
+const request = require('../utils/request');
 const scriptData = require('../utils/scriptData');
 const appList = require('../utils/appList');
 const { REQUEST_MAPPINGS } = require('../mappers/request');

--- a/lib/requesters/appsMappedRequests.js
+++ b/lib/requesters/appsMappedRequests.js
@@ -10,7 +10,7 @@ const { BASE_URL } = require('../utils/configurations');
 const appDetails = require('../app');
 
 function getBodyForRequests ({
-  numberOfApps = 50,
+  numberOfApps = 100,
   withToken = '%token%'
 }) {
   const body = `f.req=%5B%5B%5B%22qnKhOb%22%2C%22%5B%5Bnull%2C%5B%5B10%2C%5B10%2C${numberOfApps}%5D%5D%2Ctrue%2Cnull%2C%5B96%2C27%2C4%2C8%2C57%2C30%2C110%2C79%2C11%2C16%2C49%2C1%2C3%2C9%2C12%2C104%2C55%2C56%2C51%2C10%2C34%2C77%5D%5D%2Cnull%2C%5C%22${withToken}%5C%22%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`;

--- a/lib/requesters/permissionMappedRequests.js
+++ b/lib/requesters/permissionMappedRequests.js
@@ -13,12 +13,13 @@ function processPermissionData (html, opts) {
   }
 
   if (opts.short) {
-    const permissionNames = html[0].flatMap(permission => permission[0]);
+    const permissionNames = R.chain(permission => permission[0], html[0]);
     return permissionNames;
   }
 
-  const commonPermissions = html[0].flatMap(permission => permissionList.extract([2], permission, permission[0]));
-  const otherPermissions = html[1].flatMap(permission => permissionList.extract([2], permission, permission[0]));
+  const flatMapPermissions = permission => permissionList.extract([2], permission, permission[0]);
+  const commonPermissions = R.chain(flatMapPermissions, html[0]);
+  const otherPermissions = R.chain(flatMapPermissions, html[1]);
   const unknownPermissions = permissionList.extract([2], html, '');
 
   return [

--- a/lib/requesters/permissionMappedRequests.js
+++ b/lib/requesters/permissionMappedRequests.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const debug = require('debug')('google-play-scraper:permissionsMappedRequests');
+const R = require('ramda');
+const request = require('../utils/request');
+const scriptData = require('../utils/scriptData');
+const { BASE_URL } = require('../utils/configurations');
+const permissionList = require('../utils/permissionList');
+
+function processPermissionData (html) {
+  if (R.is(String, html)) {
+    html = scriptData.parse(html);
+  }
+  const commonPermissions = html[0].flatMap(permission => permissionList.extract([2], permission, permission[0]));
+  const otherPermissions = html[1].flatMap(permission => permissionList.extract([2], permission, permission[0]));
+  const unknownPermissions = permissionList.extract([2], html, '');
+
+  return [
+    ...commonPermissions,
+    ...otherPermissions,
+    ...unknownPermissions
+  ];
+}
+
+function processPermissions (opts) {
+  const body = `f.req=%5B%5B%5B%22xdSrCf%22%2C%22%5B%5Bnull%2C%5B%5C%22${opts.appId}%5C%22%2C7%5D%2C%5B%5D%5D%5D%22%2Cnull%2C%221%22%5D%5D%5D`;
+  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
+
+  debug('batchexecute URL: %s', url);
+  debug('with body: %s', body);
+
+  const requestOptions = Object.assign({
+    url,
+    method: 'POST',
+    body,
+    followAllRedirects: true,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    }
+  }, opts.requestOptions);
+
+  return request(requestOptions, opts.throttle)
+    .then((html) => {
+      const input = JSON.parse(html.substring(5));
+      const data = JSON.parse(input[0][2]);
+
+      return (data === null)
+        ? []
+        : processPermissionData(data);
+    });
+}
+
+module.exports = {
+  processPermissions
+};

--- a/lib/requesters/permissionMappedRequests.js
+++ b/lib/requesters/permissionMappedRequests.js
@@ -7,10 +7,16 @@ const scriptData = require('../utils/scriptData');
 const { BASE_URL } = require('../utils/configurations');
 const permissionList = require('../utils/permissionList');
 
-function processPermissionData (html) {
+function processPermissionData (html, opts) {
   if (R.is(String, html)) {
     html = scriptData.parse(html);
   }
+
+  if (opts.short) {
+    const permissionNames = html[0].flatMap(permission => permission[0]);
+    return permissionNames;
+  }
+
   const commonPermissions = html[0].flatMap(permission => permissionList.extract([2], permission, permission[0]));
   const otherPermissions = html[1].flatMap(permission => permissionList.extract([2], permission, permission[0]));
   const unknownPermissions = permissionList.extract([2], html, '');
@@ -46,7 +52,7 @@ function processPermissions (opts) {
 
       return (data === null)
         ? []
-        : processPermissionData(data);
+        : processPermissionData(data, opts);
     });
 }
 

--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const debug = require('debug')('google-play-scraper:appsMappedRequests');
-const request = require('../utils/request');
+const debug = require('debug')('google-play-scraper:reviewsMappedRequests');
 const R = require('ramda');
+const request = require('../utils/request');
 const scriptData = require('../utils/scriptData');
 const reviewsList = require('../utils/reviewsList');
 const { REQUEST_MAPPINGS } = require('../mappers/request');
@@ -33,7 +33,6 @@ async function processAndRecur (html, opts, savedReviews, mappings) {
     html = scriptData.parse(html);
   }
 
-  /* initial page always display sort as ratings */
   const reviews = reviewsList.extract(mappings.reviews, html, opts.appId);
   const token = R.path(mappings.reviewsToken, html);
   opts.tokenType = TOKEN_TYPES.request;

--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const debug = require('debug')('google-play-scraper:appsMappedRequests');
+const request = require('../utils/request');
+const R = require('ramda');
+const scriptData = require('../utils/scriptData');
+const reviewsList = require('../utils/reviewsList');
+const { REQUEST_MAPPINGS } = require('../mappers/request');
+const { BASE_URL } = require('../utils/configurations');
+
+const TOKEN_TYPES = {
+  initial: 'initial',
+  request: 'request'
+};
+
+function getBodyForRequests ({
+  appId,
+  sort,
+  numberOfReviews = 100,
+  withToken = '%token%',
+  tokenType = 'initial'
+}) {
+  const formBody = {
+    initial: `f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2Cnull%2C%5B2%2C${sort}%2C%5B${numberOfReviews}%2Cnull%2Cnull%5D%2Cnull%2C%5B%5D%5D%2C%5B%5C%22${appId}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`,
+    request: `f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2Cnull%2C%5B2%2C${sort}%2C%5B${numberOfReviews}%2Cnull%2C%5C%22${withToken}%5C%22%5D%2Cnull%2C%5B%5D%5D%2C%5B%5C%22${appId}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`
+  };
+
+  return formBody[tokenType];
+}
+
+async function processAndRecur (html, opts, savedReviews, mappings) {
+  if (R.is(String, html)) {
+    html = scriptData.parse(html);
+  }
+
+  /* initial page always display sort as ratings */
+  const reviews = reviewsList.extract(mappings.reviews, html, opts.appId);
+  const token = R.path(mappings.reviewsToken, html);
+  opts.tokenType = TOKEN_TYPES.request;
+
+  return checkFinished(opts, [...savedReviews, ...reviews], token);
+}
+
+function checkFinished (opts, savedReviews, nextToken) {
+  if (savedReviews.length >= opts.num || !nextToken) {
+    return savedReviews.slice(0, opts.num);
+  }
+
+  const body = getBodyForRequests({
+    appId: opts.appId,
+    sort: opts.sort,
+    numberOfReviews: opts.numberOfReviews,
+    withToken: nextToken
+  });
+  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
+
+  debug('batchexecute URL: %s', url);
+  debug('with body: %s', body);
+
+  const requestOptions = Object.assign({
+    url,
+    method: 'POST',
+    body,
+    followAllRedirects: true,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    }
+  }, opts.requestOptions);
+
+  return request(requestOptions, opts.throttle)
+    .then((html) => {
+      const input = JSON.parse(html.substring(5));
+      const data = JSON.parse(input[0][2]);
+
+      return (data === null)
+        ? savedReviews
+        : processAndRecur(data, opts, savedReviews, REQUEST_MAPPINGS);
+    });
+}
+
+function processFullReviews (opts) {
+  opts.tokenType = TOKEN_TYPES.initial;
+  return checkFinished(opts, [], '%token%');
+}
+
+module.exports = {
+  processFullReviews
+};

--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -51,7 +51,7 @@ function checkFinished (opts, savedReviews, nextToken) {
     numberOfReviews: opts.numberOfReviews,
     withToken: nextToken
   });
-  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
+  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&gl=${opts.country}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
 
   debug('batchexecute URL: %s', url);
   debug('with body: %s', body);

--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -16,7 +16,7 @@ const TOKEN_TYPES = {
 function getBodyForRequests ({
   appId,
   sort,
-  numberOfReviews = 40,
+  numberOfReviews = 100,
   withToken = '%token%',
   tokenType = 'initial'
 }) {

--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -16,7 +16,7 @@ const TOKEN_TYPES = {
 function getBodyForRequests ({
   appId,
   sort,
-  numberOfReviews = 100,
+  numberOfReviews = 40,
   withToken = '%token%',
   tokenType = 'initial'
 }) {
@@ -41,6 +41,10 @@ async function processAndRecur (html, opts, savedReviews, mappings) {
 }
 
 function checkFinished (opts, savedReviews, nextToken) {
+  debug('nextToken: %s', nextToken);
+  debug('savedReviews length: %s', savedReviews.length);
+  debug('tokenType: %s', opts.tokenType);
+
   if (savedReviews.length >= opts.num || !nextToken) {
     return savedReviews.slice(0, opts.num);
   }
@@ -48,8 +52,8 @@ function checkFinished (opts, savedReviews, nextToken) {
   const body = getBodyForRequests({
     appId: opts.appId,
     sort: opts.sort,
-    numberOfReviews: opts.num,
-    withToken: nextToken
+    withToken: nextToken,
+    tokenType: opts.tokenType
   });
   const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&gl=${opts.country}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
 

--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -48,7 +48,7 @@ function checkFinished (opts, savedReviews, nextToken) {
   const body = getBodyForRequests({
     appId: opts.appId,
     sort: opts.sort,
-    numberOfReviews: opts.numberOfReviews,
+    numberOfReviews: opts.num,
     withToken: nextToken
   });
   const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&gl=${opts.country}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -28,6 +28,7 @@ function validate (opts) {
   }
 
   opts.lang = opts.lang || 'en';
+  opts.num = 100;
 }
 
 module.exports = reviews;

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -26,7 +26,7 @@ function validate (opts) {
 
   opts.lang = opts.lang || 'en';
   opts.country = opts.country || 'us';
-  opts.num = 500;
+  opts.num = opts.num || 100;
 }
 
 module.exports = reviews;

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -23,9 +23,6 @@ function validate (opts) {
   if (opts.sort && !R.contains(opts.sort, R.values(c.sort))) {
     throw new Error('Invalid sort ' + opts.sort);
   }
-  if (opts.page && opts.page < 0) {
-    throw new Error('Page cannot be lower than 0');
-  }
 
   opts.lang = opts.lang || 'en';
   opts.num = 100;

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -25,7 +25,8 @@ function validate (opts) {
   }
 
   opts.lang = opts.lang || 'en';
-  opts.num = 100;
+  opts.country = opts.country || 'us';
+  opts.num = 500;
 }
 
 module.exports = reviews;

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -1,99 +1,18 @@
 'use strict';
 
-const request = require('./utils/request');
-const cheerio = require('cheerio');
 const R = require('ramda');
-
 const c = require('./constants');
+const { processFullReviews } = require('./requesters/reviewsMappedRequests');
 
 function reviews (opts) {
   return new Promise(function (resolve, reject) {
+    opts = R.clone(opts || {});
     validate(opts);
 
-    const options = Object.assign({
-      method: 'POST',
-      uri: 'https://play.google.com/store/getreviews',
-      form: {
-        pageNum: opts.page || 0,
-        id: opts.appId || opts.id,
-        reviewSortOrder: opts.sort || c.sort.NEWEST,
-        hl: opts.lang || 'en',
-        reviewType: 0,
-        xhr: 1
-      },
-      json: true,
-      followAllRedirects: true
-    }, opts.requestOptions);
-
-    request(options, opts.throttle)
-      .then(function (body) {
-        const response = JSON.parse(body.slice(6));
-        return response[0][2];
-      })
-      .then(cheerio.load)
-      .then(parseFields)
+    processFullReviews(opts)
       .then(resolve)
-      .catch((err) => {
-        // as of 2/10/2018 google fails with a 400 status starting on page 112
-        // assuming no more results when status is 400
-        if (err.status === 400) {
-          return resolve([]);
-        }
-        reject(err);
-      });
+      .catch(reject);
   });
-}
-
-function getUserImage ($, handle) {
-  const spanElem = $(handle).find('span[class=responsive-img-hdpi] > span');
-  const style = spanElem.length && spanElem.css('background-image');
-  // Style is in the form of url(https://lh5.googleusercontent.com/.../photo.jpg)
-  const match = style && style.match('url\\((.*)\\)');
-  return match ? match[1] : undefined;
-}
-
-function parseFields ($) {
-  const result = [];
-
-  const reviewsContainer = $('div[class=single-review]');
-  reviewsContainer.each(function (i) {
-    const id = $(this).find('div[class=review-header]').data('reviewid').trim();
-    const info = $(this).find('div[class=review-info]');
-    const userName = $(this).find('span[class=author-name]').text().trim();
-    const userImage = getUserImage($, this);
-    const date = $(this).find('span[class=review-date]').text().trim();
-    const score = parseInt(filterScore($(this).find('.star-rating-non-editable-container').attr('aria-label').trim()));
-    const url = 'https://play.google.com' + info.find('.reviews-permalink').attr('href');
-
-    const reviewContent = $(this).find('.review-body');
-    const title = reviewContent.find('span[class=review-title]').text().trim();
-    reviewContent.find('.review-link').remove();
-    const text = reviewContent.text().trim();
-
-    const developerComment = $(this).next('.developer-reply');
-    let replyDate;
-    let replyText;
-    if (developerComment.length) {
-      replyDate = developerComment.find('span.review-date').text().trim();
-      replyText = developerComment.children().remove().end().text().trim();
-    }
-
-    const allInfo = {
-      id,
-      userName,
-      userImage,
-      date,
-      url,
-      score,
-      title,
-      text,
-      replyDate,
-      replyText
-    };
-
-    result[i] = allInfo;
-  });
-  return result;
 }
 
 function validate (opts) {
@@ -107,12 +26,8 @@ function validate (opts) {
   if (opts.page && opts.page < 0) {
     throw new Error('Page cannot be lower than 0');
   }
-}
 
-function filterScore (score) {
-  // take the lower number, they're switched in japanese language
-  const numbers = score.match(/([0-5])/g);
-  return R.apply(Math.min, numbers);
+  opts.lang = opts.lang || 'en';
 }
 
 module.exports = reviews;

--- a/lib/search.js
+++ b/lib/search.js
@@ -4,6 +4,7 @@ const request = require('./utils/request');
 const scriptData = require('./utils/scriptData');
 const appList = require('./utils/appList');
 const R = require('ramda');
+const { INITIAL_MAPPINGS, REQUEST_MAPPINGS } = require('./mappers/request');
 
 const body = 'f.req=%5B%5B%5B%22qnKhOb%22%2C%22%5B%5Bnull%2C%5B%5B10%2C%5B10%2C50%5D%5D%2Ctrue%2Cnull%2C%5B96%2C27%2C4%2C8%2C57%2C30%2C110%2C79%2C11%2C16%2C49%2C1%2C3%2C9%2C12%2C104%2C55%2C56%2C51%2C10%2C34%2C77%5D%5D%2Cnull%2C%5C%22%token%%5C%22%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D';
 
@@ -73,16 +74,6 @@ function initialRequest (opts) {
     .then(skipClusterPage)
     .then((html) => processAndRecur(html, opts, [], INITIAL_MAPPINGS));
 }
-
-const INITIAL_MAPPINGS = {
-  apps: ['ds:3', 0, 1, 0, 0, 0],
-  token: ['ds:3', 0, 1, 0, 0, 7, 1]
-};
-
-const REQUEST_MAPPINGS = {
-  apps: [0, 0, 0],
-  token: [0, 0, 7, 1]
-};
 
 function getPriceGoogleValue (value) {
   switch (value.toLowerCase()) {

--- a/lib/utils/appList.js
+++ b/lib/utils/appList.js
@@ -2,7 +2,6 @@
 
 const url = require('url');
 const R = require('ramda');
-const querystring = require('querystring');
 const scriptData = require('./scriptData');
 
 const MAPPINGS = {

--- a/lib/utils/configurations.js
+++ b/lib/utils/configurations.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const BASE_URL = 'https://play.google.com';
 
 module.exports = {

--- a/lib/utils/configurations.js
+++ b/lib/utils/configurations.js
@@ -1,0 +1,5 @@
+const BASE_URL = 'https://play.google.com';
+
+module.exports = {
+  BASE_URL
+};

--- a/lib/utils/dsMappedRequests.js
+++ b/lib/utils/dsMappedRequests.js
@@ -7,6 +7,7 @@ const scriptData = require('./scriptData');
 const appList = require('./appList');
 const { REQUEST_MAPPINGS } = require('../mappers/request');
 const { BASE_URL } = require('./configurations');
+const appDetails = require('../app');
 
 function getBodyForRequests ({
   numberOfApps = 50,
@@ -17,16 +18,29 @@ function getBodyForRequests ({
   return body;
 }
 
-function processAndRecur (html, opts, savedApps, mappings) {
+async function processFullDetailApps (apps, opts) {
+  const promises = apps.map(app => (
+    appDetails({
+      appId: app.appId,
+      lang: opts.lang,
+      country: opts.country,
+      cache: opts.cache,
+      requestOptions: opts.requestOptions
+    })
+  ));
+
+  return Promise.all(promises);
+}
+
+async function processAndRecur (html, opts, savedApps, mappings) {
   if (R.is(String, html)) {
     html = scriptData.parse(html);
   }
 
-  if (html === null) {
-
-  }
-
-  const apps = appList.extract(mappings.apps, html);
+  const processedApps = appList.extract(mappings.apps, html);
+  const apps = opts.fullDetail
+    ? await processFullDetailApps(processedApps, opts)
+    : processedApps;
   const token = R.path(mappings.token, html);
 
   return checkFinished(opts, [...savedApps, ...apps], token);

--- a/lib/utils/dsMappedRequests.js
+++ b/lib/utils/dsMappedRequests.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const debug = require('debug')('google-play-scraper:dsMappedRequests');
+const request = require('./request');
+const R = require('ramda');
+const scriptData = require('./scriptData');
+const appList = require('./appList');
+const { REQUEST_MAPPINGS } = require('../mappers/request');
+const { BASE_URL } = require('./configurations');
+
+function getBodyForRequests ({
+  numberOfApps = 50,
+  withToken = '%token%'
+}) {
+  const body = `f.req=%5B%5B%5B%22qnKhOb%22%2C%22%5B%5Bnull%2C%5B%5B10%2C%5B10%2C${numberOfApps}%5D%5D%2Ctrue%2Cnull%2C%5B96%2C27%2C4%2C8%2C57%2C30%2C110%2C79%2C11%2C16%2C49%2C1%2C3%2C9%2C12%2C104%2C55%2C56%2C51%2C10%2C34%2C77%5D%5D%2Cnull%2C%5C%22${withToken}%5C%22%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`;
+
+  return body;
+}
+
+function processAndRecur (html, opts, savedApps, mappings) {
+  if (R.is(String, html)) {
+    html = scriptData.parse(html);
+  }
+
+  if (html === null) {
+
+  }
+
+  const apps = appList.extract(mappings.apps, html);
+  const token = R.path(mappings.token, html);
+
+  return checkFinished(opts, [...savedApps, ...apps], token);
+}
+
+function checkFinished (opts, savedApps, nextToken) {
+  if (savedApps.length >= opts.num || !nextToken) {
+    return savedApps.slice(0, opts.num);
+  }
+
+  const body = getBodyForRequests({
+    numberOfApps: opts.numberOfApps,
+    withToken: nextToken
+  });
+  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&gl=${opts.country}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
+
+  debug('batchexecute URL: %s', url);
+  debug('with body: %s', body);
+
+  const requestOptions = Object.assign({
+    url,
+    method: 'POST',
+    body,
+    followAllRedirects: true,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
+    }
+  }, opts.requestOptions);
+
+  return request(requestOptions, opts.throttle)
+    .then((html) => {
+      const input = JSON.parse(html.substring(5));
+      const data = JSON.parse(input[0][2]);
+
+      return (data === null)
+        ? savedApps
+        : processAndRecur(data, opts, savedApps, REQUEST_MAPPINGS);
+    });
+}
+
+module.exports = {
+  processAndRecur
+};

--- a/lib/utils/parseCategoryApps.js
+++ b/lib/utils/parseCategoryApps.js
@@ -6,7 +6,7 @@ const c = require('../constants');
 const R = require('ramda');
 const scriptData = require('./scriptData');
 const { INITIAL_MAPPINGS } = require('../mappers/request');
-const { processAndRecur } = require('./dsMappedRequests');
+const { processAndRecur } = require('../requesters/appsMappedRequests');
 const { BASE_URL } = require('./configurations');
 const appList = require('./appList');
 
@@ -37,8 +37,7 @@ function getParsedCluster (categoryObject, collection) {
     }
   };
 
-  const CATEGORY_CLUSTER_MAPPINGS = ['ds:3', 0, 1];
-  const allCategories = R.path(CATEGORY_CLUSTER_MAPPINGS, categoryObject);
+  const allCategories = R.path(INITIAL_MAPPINGS.categories, categoryObject);
   const selectedCollection = collections[allCategories.length][collection] ||
     collections[allCategories.length][c.collection.TOP_FREE];
 

--- a/lib/utils/parseCategoryApps.js
+++ b/lib/utils/parseCategoryApps.js
@@ -8,8 +8,17 @@ const scriptData = require('./scriptData');
 const { INITIAL_MAPPINGS } = require('../mappers/request');
 const { processAndRecur } = require('./dsMappedRequests');
 const { BASE_URL } = require('./configurations');
+const appList = require('./appList');
 
-function getParsedCluster (categoryObject, { category, collection }) {
+/* workaround when sometimes google changes the order of things */
+function checkIfCategoryIsReallyPaid (selectedCollection, allCategories) {
+  const CATEGORY_FIRST_APPS_MAPPINGS = [selectedCollection, 0, 0];
+  const firstApps = appList.extract(CATEGORY_FIRST_APPS_MAPPINGS, allCategories);
+
+  return !firstApps[0].free;
+}
+
+function getParsedCluster (categoryObject, collection) {
   const collections = {
     2: {
       [c.collection.TOP_FREE]: 0,
@@ -36,11 +45,25 @@ function getParsedCluster (categoryObject, { category, collection }) {
   const CATEGORY_CLUSTER_URL_MAPPINGS = [selectedCollection, 0, 3, 4, 2];
   const categoryClusterURL = R.path(CATEGORY_CLUSTER_URL_MAPPINGS, allCategories);
 
+  /* workaround when sometimes google changes the order of categories */
+  /* TOP_PAID is not shown and instead is displayed TRENDING */
+  if (collection === c.collection.TOP_PAID) {
+    return checkIfCategoryIsReallyPaid(selectedCollection, allCategories)
+      ? categoryClusterURL
+      : undefined;
+  }
+
   return categoryClusterURL;
 }
 
 function parseCategoryApps (categoryObject, opts) {
-  const clusterUrl = getParsedCluster(categoryObject, opts);
+  const { collection } = opts;
+  const clusterUrl = getParsedCluster(categoryObject, collection);
+
+  if (!clusterUrl) {
+    return [];
+  }
+
   const clusterUrlToProcess = `${BASE_URL}${clusterUrl}&hl=${opts.lang}&gl=${opts.country}`;
 
   debug('Cluster Request URL: %s', clusterUrlToProcess);

--- a/lib/utils/parseCategoryApps.js
+++ b/lib/utils/parseCategoryApps.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const debug = require('debug')('google-play-scraper:parseCategoryApps');
+const request = require('./request');
+const c = require('../constants');
+const R = require('ramda');
+const scriptData = require('./scriptData');
+const { INITIAL_MAPPINGS } = require('../mappers/request');
+const { processAndRecur } = require('./dsMappedRequests');
+const { BASE_URL } = require('./configurations');
+
+const defaultMapper = 'default';
+
+function defineCollection (category) {
+  if (category.indexOf(c.category.FAMILY) >= 0) return c.category.FAMILY;
+  if (category.indexOf(c.category.GAME) >= 0) return c.category.GAME;
+
+  return defaultMapper;
+}
+
+function getParsedCluster (categoryObject, { category, collection }) {
+  const definedCollection = defineCollection(category);
+
+  const collections = {
+    [c.category.GAME]: {
+      [c.collection.TOP_FREE]: 0,
+      [c.collection.TOP_PAID]: 1,
+      [c.collection.GROSSING]: 2
+    },
+    [c.category.FAMILY]: {
+      [c.collection.TOP_FREE]: 0,
+      [c.collection.TOP_PAID]: 1
+    },
+    default: {
+      [c.collection.TOP_FREE]: 0,
+      [c.collection.GROSSING]: 1,
+      [c.collection.TRENDING]: 2,
+      [c.collection.TOP_PAID]: 3
+    }
+  };
+
+  const selectedCollection = collections[definedCollection][collection] || collections[defaultMapper][c.collection.TOP_FREE];
+
+  const CATEGORY_CLUSTER_MAPPINGS = ['ds:3', 0, 1, selectedCollection, 0, 3, 4, 2];
+
+  return R.path(CATEGORY_CLUSTER_MAPPINGS, categoryObject);
+}
+
+function parseCategoryApps (categoryObject, opts) {
+  const clusterUrl = getParsedCluster(categoryObject, opts);
+  const clusterUrlToProcess = `${BASE_URL}${clusterUrl}&hl=${opts.lang}&gl=${opts.country}`;
+
+  debug('Cluster Request URL: %s', clusterUrlToProcess);
+
+  const options = Object.assign({
+    url: clusterUrlToProcess,
+    method: 'GET',
+    followAllRedirects: true
+  }, opts.requestOptions);
+
+  return request(options, opts.throttle)
+    .then(scriptData.parse)
+    .then(clusterObject => processAndRecur(clusterObject, opts, [], INITIAL_MAPPINGS))
+    .catch(console.error);
+}
+
+module.exports = parseCategoryApps;

--- a/lib/utils/parseCategoryApps.js
+++ b/lib/utils/parseCategoryApps.js
@@ -9,29 +9,18 @@ const { INITIAL_MAPPINGS } = require('../mappers/request');
 const { processAndRecur } = require('./dsMappedRequests');
 const { BASE_URL } = require('./configurations');
 
-const defaultMapper = 'default';
-
-function defineCollection (category) {
-  if (category.indexOf(c.category.FAMILY) >= 0) return c.category.FAMILY;
-  if (category.indexOf(c.category.GAME) >= 0) return c.category.GAME;
-
-  return defaultMapper;
-}
-
 function getParsedCluster (categoryObject, { category, collection }) {
-  const definedCollection = defineCollection(category);
-
   const collections = {
-    [c.category.GAME]: {
+    2: {
+      [c.collection.TOP_FREE]: 0,
+      [c.collection.TOP_PAID]: 1
+    },
+    3: {
       [c.collection.TOP_FREE]: 0,
       [c.collection.TOP_PAID]: 1,
       [c.collection.GROSSING]: 2
     },
-    [c.category.FAMILY]: {
-      [c.collection.TOP_FREE]: 0,
-      [c.collection.TOP_PAID]: 1
-    },
-    default: {
+    4: {
       [c.collection.TOP_FREE]: 0,
       [c.collection.GROSSING]: 1,
       [c.collection.TRENDING]: 2,
@@ -39,11 +28,15 @@ function getParsedCluster (categoryObject, { category, collection }) {
     }
   };
 
-  const selectedCollection = collections[definedCollection][collection] || collections[defaultMapper][c.collection.TOP_FREE];
+  const CATEGORY_CLUSTER_MAPPINGS = ['ds:3', 0, 1];
+  const allCategories = R.path(CATEGORY_CLUSTER_MAPPINGS, categoryObject);
+  const selectedCollection = collections[allCategories.length][collection] ||
+    collections[allCategories.length][c.collection.TOP_FREE];
 
-  const CATEGORY_CLUSTER_MAPPINGS = ['ds:3', 0, 1, selectedCollection, 0, 3, 4, 2];
+  const CATEGORY_CLUSTER_URL_MAPPINGS = [selectedCollection, 0, 3, 4, 2];
+  const categoryClusterURL = R.path(CATEGORY_CLUSTER_URL_MAPPINGS, allCategories);
 
-  return R.path(CATEGORY_CLUSTER_MAPPINGS, categoryObject);
+  return categoryClusterURL;
 }
 
 function parseCategoryApps (categoryObject, opts) {

--- a/lib/utils/permissionList.js
+++ b/lib/utils/permissionList.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const R = require('ramda');
+const scriptData = require('./scriptData');
+
+function getPermissionMappings (type) {
+  const MAPPINGS = {
+    permission: [1],
+    description: [1],
+    type: {
+      path: 0,
+      fun: () => type
+    }
+  };
+
+  return MAPPINGS;
+}
+
+function extract (root, data, type) {
+  const input = R.path(root, data);
+  const MAPPINGS = getPermissionMappings(type);
+  return R.map(scriptData.extractor(MAPPINGS), input);
+}
+
+module.exports = { getPermissionMappings, extract };

--- a/lib/utils/reviewsList.js
+++ b/lib/utils/reviewsList.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const R = require('ramda');
+const scriptData = require('./scriptData');
+const { BASE_URL } = require('./configurations');
+
+function getReviewsMappings (appId) {
+  const MAPPINGS = {
+    id: [0],
+    userName: [1, 0],
+    userImage: [1, 1, 3, 2],
+    date: {
+      path: [5],
+      fun: generateDate
+    },
+    score: [2],
+    scoreText: {
+      path: [2],
+      fun: (score) => String(score)
+    },
+    url: {
+      path: [0],
+      fun: (reviewId) => `${BASE_URL}/store/apps/details?id=${appId}&reviewId=${reviewId}`
+    },
+    title: {
+      path: [0],
+      fun: () => null
+    },
+    text: [4],
+    replyDate: {
+      path: [7, 2],
+      fun: generateDate
+    },
+    replyText: {
+      path: [7, 1],
+      fun: (text) => text || null
+    },
+    version: [10],
+    thumbsUp: [6]
+  };
+
+  return MAPPINGS;
+}
+
+function generateDate (dateArray) {
+  if (!dateArray) {
+    return null;
+  }
+
+  const millisecondsTotal = `${dateArray[0]}${String(dateArray[1]).substring(0, 3)}`;
+  const time = new Date(Number(millisecondsTotal));
+
+  return String(time);
+}
+
+/*
+ * Apply MAPPINGS for each application in list from root path
+*/
+function extract (root, data, appId) {
+  const input = R.path(root, data);
+  const MAPPINGS = getReviewsMappings(appId);
+  return R.map(scriptData.extractor(MAPPINGS), input);
+}
+
+module.exports = { getReviewsMappings, extract };

--- a/lib/utils/reviewsList.js
+++ b/lib/utils/reviewsList.js
@@ -44,7 +44,7 @@ function getReviewsMappings (appId) {
     thumbsUp: [6],
     criterias: {
       path: [12, 0],
-      fun: (criterias) => criterias.map(buildCriteria)
+      fun: (criterias = []) => criterias.map(buildCriteria)
     }
   };
 

--- a/lib/utils/reviewsList.js
+++ b/lib/utils/reviewsList.js
@@ -4,6 +4,11 @@ const R = require('ramda');
 const scriptData = require('./scriptData');
 const { BASE_URL } = require('./configurations');
 
+const buildCriteria = (criteria) => ({
+  criteria: criteria[0],
+  rating: criteria[1] ? criteria[1][0] : null      
+});
+
 function getReviewsMappings (appId) {
   const MAPPINGS = {
     id: [0],
@@ -36,7 +41,11 @@ function getReviewsMappings (appId) {
       fun: (text) => text || null
     },
     version: [10],
-    thumbsUp: [6]
+    thumbsUp: [6],
+    criterias: {
+      path: [12, 0],
+      fun: (criterias) => criterias.map(buildCriteria)
+    }
   };
 
   return MAPPINGS;

--- a/package-lock.json
+++ b/package-lock.json
@@ -314,11 +314,18 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "deep-eql": {
@@ -569,6 +576,17 @@
       "requires": {
         "debug": "^2.6.9",
         "resolve": "^1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -579,6 +597,17 @@
       "requires": {
         "debug": "^2.6.8",
         "pkg-dir": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-es": {
@@ -610,6 +639,15 @@
         "resolve": "^1.10.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -1362,7 +1400,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/facundoolano/google-play-scraper",
   "dependencies": {
     "cheerio": "^0.22.0",
-    "debug": "^2.2.0",
+    "debug": "^4.1.1",
     "eslint": "^5.16.0",
     "memoizee": "^0.4.11",
     "ramda": "^0.21.0",

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -7,6 +7,8 @@ const assertValidUrl = require('./common').assertValidUrl;
 const gplay = require('../index');
 
 describe('List method', () => {
+  const timeout = 10 * 1000;
+
   it('should fetch a valid application list for the given category and collection', () => {
     return gplay.list({
       category: gplay.category.GAME_ACTION,
@@ -14,7 +16,7 @@ describe('List method', () => {
     })
       .then((apps) => apps.map(assertValidApp))
       .then((apps) => apps.map((app) => assert(app.free)));
-  });
+  }).timeout(timeout);
 
   it('should validate the category', () => {
     return gplay.list({
@@ -42,16 +44,6 @@ describe('List method', () => {
     })
       .then(assert.fail)
       .catch((e) => assert.equal(e.message, 'Invalid age range elderly'));
-  });
-
-  it('should validate the results number', () => {
-    return gplay.list({
-      category: gplay.category.GAME_ACTION,
-      collection: gplay.collection.TOP_FREE,
-      num: 200
-    })
-      .then(assert.fail)
-      .catch((e) => assert.equal(e.message, 'Cannot retrieve more than 120 apps at a time'));
   });
 
   it('should validate the start number', () => {
@@ -104,7 +96,7 @@ describe('List method', () => {
         app.screenshots.map(assertValidUrl);
         app.comments.map(assert.isString);
       }));
-  }).timeout(10 * 1000);
+  }).timeout(timeout);
 
   // fetch last page of new paid apps, which have a bigger chance of including
   // results with no downloads (less fields, prone to failures)
@@ -127,7 +119,7 @@ describe('List method', () => {
       fullDetail: true
     })
       .then((apps) => apps.map(assertValidApp))
-  ).timeout(10 * 1000);
+  ).timeout(timeout);
 
   it('should be able to retreive a list for each category', () => {
     const categoryIds = Object.keys(gplay.category);

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -104,7 +104,7 @@ describe('List method', () => {
         app.screenshots.map(assertValidUrl);
         app.comments.map(assert.isString);
       }));
-  });
+  }).timeout(10 * 1000);
 
   // fetch last page of new paid apps, which have a bigger chance of including
   // results with no downloads (less fields, prone to failures)
@@ -115,7 +115,8 @@ describe('List method', () => {
       num: 20,
       start: 500
     })
-      .then((apps) => apps.map(assertValidApp)));
+      .then((apps) => apps.map(assertValidApp))
+  );
 
   it('It should not fail with apps with no downloads and fullDetail', () =>
     gplay.list({
@@ -125,7 +126,8 @@ describe('List method', () => {
       start: 500,
       fullDetail: true
     })
-      .then((apps) => apps.map(assertValidApp)));
+      .then((apps) => apps.map(assertValidApp))
+  ).timeout(10 * 1000);
 
   it('should be able to retreive a list for each category', () => {
     const categoryIds = Object.keys(gplay.category);
@@ -143,5 +145,5 @@ describe('List method', () => {
     };
 
     return categoryIds.reduce(fetchSequentially, Promise.resolve());
-  }).timeout(60 * 1000);
+  }).timeout(90 * 1000);
 });

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -7,7 +7,7 @@ const assertValidUrl = require('./common').assertValidUrl;
 const gplay = require('../index');
 
 describe('List method', () => {
-  const timeout = 10 * 1000;
+  const timeout = 15 * 1000;
 
   it('should fetch a valid application list for the given category and collection', () => {
     return gplay.list({

--- a/test/lib.permissions.js
+++ b/test/lib.permissions.js
@@ -11,11 +11,12 @@ describe('Permissions method', () => {
         results.map((perm) => {
           assert.isString(perm.permission);
           assert.isString(perm.description);
+          assert.isString(perm.type);
         });
       }));
 
   it('should return skip descriptions if short option is passed', () =>
-    gplay.suggest({ term: 'p' })
+    gplay.permissions({ appId: 'com.sgn.pandapop.gp', short: true })
       .then((results) => {
         assert(results.length);
         results.map(assert.isString);

--- a/test/lib.reviews.js
+++ b/test/lib.reviews.js
@@ -18,6 +18,10 @@ function assertValid (review) {
   assert(review.score > 0);
   assert(review.score <= 5);
   assertValidUrl(review.url);
+  assert.hasAnyKeys(review, 'replyDate');
+  assert.hasAnyKeys(review, 'replyText');
+  assert.hasAnyKeys(review, 'version');
+  assert.hasAnyKeys(review, 'thumbsUp');
 }
 
 describe('Reviews method', () => {

--- a/test/lib.reviews.js
+++ b/test/lib.reviews.js
@@ -12,7 +12,7 @@ function assertValid (review) {
   assert(review.userName);
   assert.isString(review.date);
   assert(review.date);
-  assert.isString(review.title);
+  assert.isNull(review.title);
   assert.isString(review.text);
   assert.isNumber(review.score);
   assert(review.score > 0);


### PR DESCRIPTION
This PR fixes the following issues: 
#333 
#334 
#335 
#336 

I have updated the following methods:
 ```.list```
 ```.reviews```
 ```.permissions```
 ```.categories```

 ```.list ``` and  ```.reviews ``` methods introduce some breaking changes, since google allow you to fetch data only through ```batchexecute``` endpoint.
You can now only send the ```num``` parameter (it will allow you to fetch the desired number of category apps and reviews).
The ```.list``` method is unstable right now, since google sometimes respond with 200 apps, and sometimes more (for example 600 and so on).

For the ```.permissions``` method I've added the ```type``` parameter to the response (since this is not a breaking change but add value to it).
For the ```.reviews``` method I've added the ```thumbsUp``` and ```version``` parameters, this is also not a breaking change.

I've also updated the tests and docs