### PR TITLE
fix .categories method (store update 2019-09-01)

### DIFF
--- a/lib/categories.js
+++ b/lib/categories.js
@@ -4,7 +4,7 @@ const request = require('./utils/request');
 const cheerio = require('cheerio');
 
 const PLAYSTORE_URL = 'https://play.google.com/store/apps';
-const CATEGORY_URL_PREFIX = 'https://play.google.com/store/apps/category/';
+const CATEGORY_URL_PREFIX = '/store/apps/category/';
 
 function categories (opts) {
   opts = Object.assign({}, opts);


### PR DESCRIPTION
I have updated the following methods:
```.categories```

Category URL was changed in google play