### PR TITLE
.catch to reject promise in .permissions method

### DIFF
--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -12,7 +12,7 @@ function permissions (opts) {
 
     processPermissions(opts)
       .then(resolve)
-      .then(reject);
+      .catch(reject);
   });
 }
 


### PR DESCRIPTION
I've update the following method:
`.permissions`

Just fixing a small bug at the last version
In this case we should use .catch for rejecting a promise, instead of .then