### PR TITLE
fix null reviews date

### DIFF
--- a/lib/utils/reviewsList.js
+++ b/lib/utils/reviewsList.js
@@ -59,7 +59,7 @@ function generateDate (dateArray) {
     return null;
   }
 
-  const millisecondsLastDigits = String(dateArray[1]) || '000';
+  const millisecondsLastDigits = String(dateArray[1] || '000');
   const millisecondsTotal = `${dateArray[0]}${millisecondsLastDigits.substring(0, 3)}`;
   const date = new Date(Number(millisecondsTotal));
 

--- a/test/lib.reviews.js
+++ b/test/lib.reviews.js
@@ -11,6 +11,7 @@ function assertValid (review) {
   assert.isString(review.userName);
   assertValidUrl(review.userImage);
   assert(review.userName);
+  assert.isNotNull(new Date(review.date).toJSON());
   assert.isString(review.date);
   assert(review.date);
   assert.isNull(review.title);


### PR DESCRIPTION
This PR fixes the following issues:
#348

I have updated the following methods:
`.reviews`

A last minute change brought the bug again.
The issue related object now returns as follows:
```
  {
    id: 'gp:AOqpTOH8ZUv5em6TQwWMbnKqPtEWngJ9Ts-S_PsVycbHvtRhL0qIPRzrO8_TVHodY5-v-0W1GRb3kiObyc9oHw',
    userName: 'K. Bacon',
    userImage: 'https://lh3.googleusercontent.com/-bsw62Zcu8JI/AAAAAAAAAAI/AAAAAAAAAAA/ACHi3rfRA9WjZvNztK8jPCa2rWsuf99Uyw/photo.jpg',
    date: '2019-04-10T07:26:10.000Z',
    score: 4,
    scoreText: '4',
    url: 'https://play.google.com/store/apps/details?id=jp.co.recruit.rikunabihaken.rikunabihaken&reviewId=gp:AOqpTOH8ZUv5em6TQwWMbnKqPtEWngJ9Ts-S_PsVycbHvtRhL0qIPRzrO8_TVHodY5-v-0W1GRb3kiObyc9oHw',
    title: null,
    text: '概ね良好です。経歴などリクナビNEXTと同期していただければ、有難いです。',
    replyDate: null,
    replyText: null,
    version: '2.8.1',
    thumbsUp: 7,
    criterias: [ [Object], [Object], [Object] ]
  },
``` 