### PR TITLE
fix .permission errors

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -85,3 +85,8 @@ module.exports.age = {
   SIX_EIGHT: 'AGE_RANGE2',
   NINE_UP: 'AGE_RANGE3'
 };
+
+module.exports.permission = {
+  COMMON: 0,
+  OTHER: 1
+};

--- a/lib/mappers/permissions.js
+++ b/lib/mappers/permissions.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const MAPPINGS = {
+  permissions: [2],
+  type: 0
+};
+
+module.exports = {
+  MAPPINGS
+};

--- a/lib/requesters/permissionMappedRequests.js
+++ b/lib/requesters/permissionMappedRequests.js
@@ -6,6 +6,8 @@ const request = require('../utils/request');
 const scriptData = require('../utils/scriptData');
 const { BASE_URL } = require('../utils/configurations');
 const permissionList = require('../utils/permissionList');
+const { MAPPINGS } = require('../mappers/permissions');
+const c = require('../constants');
 
 function processPermissionData (html, opts) {
   if (R.is(String, html)) {
@@ -13,19 +15,21 @@ function processPermissionData (html, opts) {
   }
 
   if (opts.short) {
-    const permissionNames = R.chain(permission => permission[0], html[0]);
+    const validPermissions = html[c.permission.COMMON].filter(permission => permission.length);
+    const permissionNames = R.chain(permission => permission[MAPPINGS.type], validPermissions);
     return permissionNames;
   }
 
-  const flatMapPermissions = permission => permissionList.extract([2], permission, permission[0]);
-  const commonPermissions = R.chain(flatMapPermissions, html[0]);
-  const otherPermissions = R.chain(flatMapPermissions, html[1]);
-  const unknownPermissions = permissionList.extract([2], html, '');
+  const flatMapPermissions = permission => permissionList.extract(MAPPINGS.permissions, permission, permission[MAPPINGS.type]);
+  const commonPermissions = R.chain(flatMapPermissions, html[c.permission.COMMON]);
+  debug('commonPermissions %o', commonPermissions);
+
+  const otherPermissions = R.chain(flatMapPermissions, html[c.permission.OTHER]);
+  debug('otherPermissions %o', otherPermissions);
 
   return [
     ...commonPermissions,
-    ...otherPermissions,
-    ...unknownPermissions
+    ...otherPermissions
   ];
 }
 

--- a/lib/utils/permissionList.js
+++ b/lib/utils/permissionList.js
@@ -17,6 +17,11 @@ function getPermissionMappings (type) {
 
 function extract (root, data, type) {
   const input = R.path(root, data);
+
+  if (typeof input === 'undefined') {
+    return [];
+  }
+
   const MAPPINGS = getPermissionMappings(type);
   return R.map(scriptData.extractor(MAPPINGS), input);
 }

--- a/test/lib.permissions.js
+++ b/test/lib.permissions.js
@@ -14,8 +14,25 @@ describe('Permissions method', () => {
         });
       }));
 
+  it('should return an array of permissions and descriptions for different response format', () =>
+    gplay.permissions({ appId: 'air.tv.ingames.cubematch.free' })
+      .then((results) => {
+        assert(results.length);
+        results.map((perm) => {
+          assert.isString(perm.permission);
+          assert.isString(perm.type);
+        });
+      }));
+
   it('should return skip descriptions if short option is passed', () =>
     gplay.permissions({ appId: 'com.sgn.pandapop.gp', short: true })
+      .then((results) => {
+        assert(results.length);
+        results.map(assert.isString);
+      }));
+
+  it('should return skip descriptions if short option is passed for different response format', () =>
+    gplay.permissions({ appId: 'air.tv.ingames.cubematch.free', short: true })
       .then((results) => {
         assert(results.length);
         results.map(assert.isString);


### PR DESCRIPTION
This PR fixes the following issue:
#356 

I have updated the following methods:
`.permission`

There are in fact two errors:
Google returns 3 arrays for permissions: `common` (Store, Location, etc), `other`, and a third one without any type.

Sometimes the `common` permissions array returns like this:
```
[ [], [ 'Location', [ null, 2, null, [Array] ], [ [Array] ] ], [ 'Photos/Media/Files', [ null, 2, null, [Array] ], [ [Array], [Array] ] ], [ 'Storage', [ null, 2, null, [Array] ], [ [Array], [Array] ] ], [ 'Wi-Fi connection information', [ null, 2, null, [Array] ], [ [Array] ] ] ]
```

The first empty array was preventing the module from get all other permissions and throwing the error.

The second one is basically the same thing but with the third permission array that have no `type` associated, and it is not shown at the gplay store, so I basically removed it.