### PR TITLE
add IAPRange field on .app method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Results:
   currency: 'USD',
   priceText: 'Free',
   offersIAP: false,
+  IAPRange: undefined,
   size: '34M',
   androidVersion: '2.3',
   androidVersionText: '2.3 and up',

--- a/lib/app.js
+++ b/lib/app.js
@@ -84,14 +84,13 @@ const MAPPINGS = {
     path: ['ds:5', 0, 12, 12, 0],
     fun: Boolean
   },
-
+  IAPRange: ['ds:5', 0, 12, 12, 0],
   size: ['ds:8', 0],
   androidVersion: {
     path: ['ds:8', 2],
     fun: normalizeAndroidVersion
   },
   androidVersionText: ['ds:8', 2],
-
   developer: ['ds:5', 0, 12, 5, 1],
   developerId: {
     path: ['ds:5', 0, 12, 5, 5, 4, 2],
@@ -106,7 +105,6 @@ const MAPPINGS = {
   genreId: ['ds:5', 0, 12, 13, 0, 2],
   familyGenre: ['ds:5', 0, 12, 13, 1, 0],
   familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
-
   icon: ['ds:5', 0, 12, 1, 3, 2],
   headerImage: ['ds:5', 0, 12, 2, 3, 2],
   screenshots: {
@@ -115,27 +113,23 @@ const MAPPINGS = {
   },
   video: ['ds:5', 0, 12, 3, 0, 3, 2],
   videoImage: ['ds:5', 0, 12, 3, 1, 3, 2],
-
   contentRating: ['ds:5', 0, 12, 4, 0],
   contentRatingDescription: ['ds:5', 0, 12, 4, 2, 1],
   adSupported: {
     path: ['ds:5', 0, 12, 14, 0],
     fun: Boolean
   },
-
   released: ['ds:5', 0, 12, 36],
   updated: {
     path: ['ds:5', 0, 12, 8, 0],
     fun: (ts) => ts * 1000
   },
-
   version: ['ds:8', 1],
   recentChanges: ['ds:5', 0, 12, 6, 1],
   comments: {
-    path: ['ds:15', 0],
+    path: ['ds:16', 0],
     fun: extractComments
   }
-
 };
 
 function descriptionText (description) {

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -42,8 +42,9 @@ describe('App method', () => {
 
         assert.equal(app.priceText, 'Free');
         assert.equal(app.price, 0);
-        assert(app.free === true);
-        assert.equal(app.offersIAP, true);
+        assert.isTrue(app.free);
+        assert.isTrue(app.offersIAP);
+        assert.isString(app.IAPRange);
         // assert(app.preregister === false);
 
         assert.equal(app.developer, 'Jam City, Inc.');
@@ -58,7 +59,7 @@ describe('App method', () => {
         assert(app.screenshots.length);
         app.screenshots.map(assertValidUrl);
 
-        assert(app.comments.length);
+        assert.isArray(app.comments);
         app.comments.map(assert.isString);
 
         assert.isString(app.recentChanges);


### PR DESCRIPTION
This PR implement the request in the following issue:
#331 

I have updated the following methods:
`.app`

I have introduced the `IAPRange` field (now you can get the IAP range given by gplay store) and also fixed the `comments` field that was returning undefined.
I have also updated the docs and tests.