### PR TITLE
fix .permission method when app has no common permissions

### DIFF
--- a/lib/requesters/permissionMappedRequests.js
+++ b/lib/requesters/permissionMappedRequests.js
@@ -22,7 +22,7 @@ function processShortPermissionsData (html) {
     return [];
   }
 
-  const validPermissions = html[c.permission.COMMON].filter(permission => permission.length);
+  const validPermissions = commonPermissions.filter(permission => permission.length);
   const permissionNames = R.chain(permission => permission[MAPPINGS.type], validPermissions);
   return permissionNames;
 }
@@ -31,6 +31,8 @@ function processPermissionData (html) {
   if (R.is(String, html)) {
     html = scriptData.parse(html);
   }
+
+  debug(`html %o`, html);
 
   const permissions = Object.values(c.permission).reduce((permissionAccummulator, permission) => {
     if (!html[permission]) {

--- a/lib/requesters/permissionMappedRequests.js
+++ b/lib/requesters/permissionMappedRequests.js
@@ -9,28 +9,44 @@ const permissionList = require('../utils/permissionList');
 const { MAPPINGS } = require('../mappers/permissions');
 const c = require('../constants');
 
-function processPermissionData (html, opts) {
+const flatMapPermissions = permission => permissionList.extract(MAPPINGS.permissions, permission, permission[MAPPINGS.type]);
+
+function processShortPermissionsData (html) {
   if (R.is(String, html)) {
     html = scriptData.parse(html);
   }
 
-  if (opts.short) {
-    const validPermissions = html[c.permission.COMMON].filter(permission => permission.length);
-    const permissionNames = R.chain(permission => permission[MAPPINGS.type], validPermissions);
-    return permissionNames;
+  const commonPermissions = html[c.permission.COMMON];
+
+  if (!commonPermissions) {
+    return [];
   }
 
-  const flatMapPermissions = permission => permissionList.extract(MAPPINGS.permissions, permission, permission[MAPPINGS.type]);
-  const commonPermissions = R.chain(flatMapPermissions, html[c.permission.COMMON]);
-  debug('commonPermissions %o', commonPermissions);
+  const validPermissions = html[c.permission.COMMON].filter(permission => permission.length);
+  const permissionNames = R.chain(permission => permission[MAPPINGS.type], validPermissions);
+  return permissionNames;
+}
 
-  const otherPermissions = R.chain(flatMapPermissions, html[c.permission.OTHER]);
-  debug('otherPermissions %o', otherPermissions);
+function processPermissionData (html) {
+  if (R.is(String, html)) {
+    html = scriptData.parse(html);
+  }
 
-  return [
-    ...commonPermissions,
-    ...otherPermissions
-  ];
+  const permissions = Object.values(c.permission).reduce((permissionAccummulator, permission) => {
+    if (!html[permission]) {
+      return permissionAccummulator;
+    }
+
+    permissionAccummulator.push(
+      ...R.chain(flatMapPermissions, html[permission])
+    );
+
+    return permissionAccummulator;
+  }, []);
+
+  debug(`Permissions %o`, permissions);
+
+  return permissions;
 }
 
 function processPermissions (opts) {
@@ -55,9 +71,13 @@ function processPermissions (opts) {
       const input = JSON.parse(html.substring(5));
       const data = JSON.parse(input[0][2]);
 
-      return (data === null)
-        ? []
-        : processPermissionData(data, opts);
+      if (data === null) {
+        return [];
+      }
+
+      return (opts.short)
+        ? processShortPermissionsData(data)
+        : processPermissionData(data);
     });
 }
 

--- a/test/lib.permissions.js
+++ b/test/lib.permissions.js
@@ -37,4 +37,20 @@ describe('Permissions method', () => {
         assert(results.length);
         results.map(assert.isString);
       }));
+
+  it('should return even if app have no common permissions', () =>
+    gplay.permissions({ appId: 'com.skybornegames.battlepop' })
+      .then((results) => {
+        assert(results.length);
+        results.map((perm) => {
+          assert.isString(perm.permission);
+          assert.isString(perm.type);
+        });
+      }));
+
+  it('should return empty if app have no common permissions and short option is passed', () =>
+    gplay.permissions({ appId: 'com.skybornegames.battlepop', short: true })
+      .then((results) => {
+        assert.equal(0, results.length);
+      }));
 });


### PR DESCRIPTION
This PR fixes the following issue:
#359 

I have updated the following methods:
`.permission`

This change fix the error when an app have no "common permissions" array.
The response from google is this:
```
[ null, [ [ 'Other', [Array], [Array] ] ], [ [ null, 'receive data from Internet' ] ] ]
```

Now, I'm checking for every permission array, and returning only the ones that have data.