### PR TITLE
Fix paginated search results when country and lang are set

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -33,7 +33,7 @@ function checkFinished (opts, savedApps, nextToken) {
   }
 
   const requestOptions = Object.assign({
-    url: 'https://play.google.com/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&bl=boq_playuiserver_20190424.04_p0&hl=en&gl=us&authuser=0&soc-app=121&soc-platform=1&soc-device=1',
+    url: `https://play.google.com/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&bl=boq_playuiserver_20190424.04_p0&hl=${opts.lang}&gl=${opts.country}&authuser=0&soc-app=121&soc-platform=1&soc-device=1`,
     method: 'POST',
     body: body.replace('%token%', nextToken),
     followAllRedirects: true,


### PR DESCRIPTION
This PR fixes the following issue:
 - When searching for a keyword with country / lang via `.search` method, paginated results are different from the store

I have updated the following methods:
`.search` 

This change fix the above mentioned error.
The error is caused due to the fact that the first request is made with the right data (country + lang) but, the paginated requests are **always** made with **country=us** and **lang=en**