### PR TITLE
Avoid exception when search doesn't get results

### DIFF
--- a/lib/utils/appList.js
+++ b/lib/utils/appList.js
@@ -40,6 +40,7 @@ function extaractDeveloperId (link) {
 
 function extract (root, data) {
   const input = R.path(root, data);
+  if (input === undefined) return [];
   return R.map(scriptData.extractor(MAPPINGS), input);
 }
 


### PR DESCRIPTION
When searching for a random text that doesn't return search results, the library throws an exception instead of returning an empty list.

Eg. this API call produces an error: "TypeError: Cannot read property 'map' of undefined".

`gplay.search({term: "fklsdjlkjhfe", num: 2}).then(console.log, console.log);`

This PR fixes the issue.

