### PR TITLE
fix .app method (store update 2020-06-16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Results:
   summary: 'The world is closer than ever with over 100 languages',
   installs: '500,000,000+',
   minInstalls: 500000000,
+  maxInstalls: 898626813,
   score: 4.482483,
   scoreText: '4.5',
   ratings: 6811669,

--- a/lib/app.js
+++ b/lib/app.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const debug = require('debug')('google-play-scraper:app');
-const request = require('./utils/request');
-const queryString = require('querystring');
-const cheerio = require('cheerio');
 const R = require('ramda');
+const queryString = require('querystring');
+const request = require('./utils/request');
 const scriptData = require('./utils/scriptData');
+const MAPPINGS = require('./mappers/details');
 
 const PLAYSTORE_URL = 'https://play.google.com/store/apps/details';
 
@@ -39,159 +38,6 @@ function app (opts) {
       .then(resolve)
       .catch(reject);
   });
-}
-
-// TODO may need to do html to text in some of the fields
-
-const MAPPINGS = {
-  // FIXME add appId
-
-  title: ['ds:5', 0, 0, 0],
-  description: {
-    path: ['ds:5', 0, 10, 0, 1],
-    fun: descriptionText
-  },
-  descriptionHTML: ['ds:5', 0, 10, 0, 1],
-  summary: ['ds:5', 0, 10, 1, 1],
-  installs: ['ds:5', 0, 12, 9, 0],
-  minInstalls: {
-    path: ['ds:5', 0, 12, 9, 0],
-    fun: cleanInt
-  },
-  score: ['ds:6', 0, 6, 0, 1],
-  scoreText: ['ds:6', 0, 6, 0, 0],
-  ratings: ['ds:6', 0, 6, 2, 1],
-  reviews: ['ds:6', 0, 6, 3, 1],
-  histogram: {
-    path: ['ds:6', 0, 6, 1],
-    fun: buildHistogram
-  },
-
-  price: {
-    path: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 0],
-    fun: (val) => val / 1000000 || 0
-  },
-  free: {
-    path: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 0],
-    // considered free only if price is exactly zero
-    fun: (val) => val === 0
-  },
-  currency: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 1],
-  priceText: {
-    path: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 2],
-    fun: priceText
-  },
-  offersIAP: {
-    path: ['ds:5', 0, 12, 12, 0],
-    fun: Boolean
-  },
-  IAPRange: ['ds:5', 0, 12, 12, 0],
-  size: ['ds:8', 0],
-  androidVersion: {
-    path: ['ds:8', 2],
-    fun: normalizeAndroidVersion
-  },
-  androidVersionText: ['ds:8', 2],
-  developer: ['ds:5', 0, 12, 5, 1],
-  developerId: {
-    path: ['ds:5', 0, 12, 5, 5, 4, 2],
-    fun: (devUrl) => devUrl.split('id=')[1]
-  },
-  developerEmail: ['ds:5', 0, 12, 5, 2, 0],
-  developerWebsite: ['ds:5', 0, 12, 5, 3, 5, 2],
-  developerAddress: ['ds:5', 0, 12, 5, 4, 0],
-  privacyPolicy: ['ds:5', 0, 12, 7, 2],
-  developerInternalID: ['ds:5', 0, 12, 5, 0, 0],
-  genre: ['ds:5', 0, 12, 13, 0, 0],
-  genreId: ['ds:5', 0, 12, 13, 0, 2],
-  familyGenre: ['ds:5', 0, 12, 13, 1, 0],
-  familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
-  icon: ['ds:5', 0, 12, 1, 3, 2],
-  headerImage: ['ds:5', 0, 12, 2, 3, 2],
-  screenshots: {
-    path: ['ds:5', 0, 12, 0],
-    fun: (screenshots) => {
-      if (screenshots === null) return [];
-      return screenshots.map(R.path([3, 2]));
-    }
-  },
-  video: ['ds:5', 0, 12, 3, 0, 3, 2],
-  videoImage: ['ds:5', 0, 12, 3, 1, 3, 2],
-  contentRating: ['ds:5', 0, 12, 4, 0],
-  contentRatingDescription: ['ds:5', 0, 12, 4, 2, 1],
-  adSupported: {
-    path: ['ds:5', 0, 12, 14, 0],
-    fun: Boolean
-  },
-  released: ['ds:5', 0, 12, 36],
-  updated: {
-    path: ['ds:5', 0, 12, 8, 0],
-    fun: (ts) => ts * 1000
-  },
-  version: ['ds:8', 1],
-  recentChanges: ['ds:5', 0, 12, 6, 1],
-  comments: {
-    path: ['ds:18', 0],
-    fun: extractComments
-  },
-  editorsChoice: {
-    path: ['ds:5', 0, 12, 15, 0],
-    fun: Boolean
-  }
-};
-
-function descriptionText (description) {
-  // preserve the line breaks when converting to text
-  const html = cheerio.load('<div>' + description.replace(/<br>/g, '\r\n') + '</div>');
-  return cheerio.text(html('div'));
-}
-
-function priceText (priceText) {
-  // Return Free if the price text is empty
-  if (!priceText) {
-    return 'Free';
-  }
-  return priceText;
-}
-
-function cleanInt (number) {
-  number = number || '0';
-  number = number.replace(/[^\d]/g, ''); // removes thousands separator
-  return parseInt(number);
-}
-
-function normalizeAndroidVersion (androidVersionText) {
-  const number = androidVersionText.split(' ')[0];
-  if (parseFloat(number)) {
-    return number;
-  }
-  return 'VARY';
-}
-
-function buildHistogram (container) {
-  if (!container) {
-    return { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
-  }
-  return {
-    1: container[1][1],
-    2: container[2][1],
-    3: container[3][1],
-    4: container[4][1],
-    5: container[5][1]
-  };
-}
-
-function extractComments (comments) {
-  if (!comments) {
-    return [];
-  }
-
-  debug('comments: %O', comments);
-
-  return R.compose(
-    R.take(5),
-    R.reject(R.isNil),
-    R.pluck(4))(comments);
 }
 
 module.exports = app;

--- a/lib/mappers/details.js
+++ b/lib/mappers/details.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const R = require('ramda');
+const debug = require('debug')('google-play-scraper:mappers:details');
+const cheerio = require('cheerio');
+
+const MAPPINGS = {
+  // FIXME add appId
+  title: ['ds:5', 0, 0, 0],
+  description: {
+    path: ['ds:5', 0, 10, 0, 1],
+    fun: descriptionText
+  },
+  descriptionHTML: ['ds:5', 0, 10, 0, 1],
+  summary: ['ds:5', 0, 10, 1, 1],
+  installs: ['ds:5', 0, 12, 9, 0],
+  minInstalls: ['ds:5', 0, 12, 9, 1],
+  maxInstalls: ['ds:5', 0, 12, 9, 2],
+  score: ['ds:6', 0, 6, 0, 1],
+  scoreText: ['ds:6', 0, 6, 0, 0],
+  ratings: ['ds:6', 0, 6, 2, 1],
+  reviews: ['ds:6', 0, 6, 3, 1],
+  histogram: {
+    path: ['ds:6', 0, 6, 1],
+    fun: buildHistogram
+  },
+
+  price: {
+    path: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 0],
+    fun: (val) => val / 1000000 || 0
+  },
+  free: {
+    path: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 0],
+    // considered free only if price is exactly zero
+    fun: (val) => val === 0
+  },
+  currency: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 1],
+  priceText: {
+    path: ['ds:3', 0, 2, 0, 0, 0, 1, 0, 2],
+    fun: priceText
+  },
+  offersIAP: {
+    path: ['ds:5', 0, 12, 12, 0],
+    fun: Boolean
+  },
+  IAPRange: ['ds:5', 0, 12, 12, 0],
+  size: ['ds:8', 0],
+  androidVersion: {
+    path: ['ds:8', 2],
+    fun: normalizeAndroidVersion
+  },
+  androidVersionText: ['ds:8', 2],
+  developer: ['ds:5', 0, 12, 5, 1],
+  developerId: {
+    path: ['ds:5', 0, 12, 5, 5, 4, 2],
+    fun: (devUrl) => devUrl.split('id=')[1]
+  },
+  developerEmail: ['ds:5', 0, 12, 5, 2, 0],
+  developerWebsite: ['ds:5', 0, 12, 5, 3, 5, 2],
+  developerAddress: ['ds:5', 0, 12, 5, 4, 0],
+  privacyPolicy: ['ds:5', 0, 12, 7, 2],
+  developerInternalID: ['ds:5', 0, 12, 5, 0, 0],
+  genre: ['ds:5', 0, 12, 13, 0, 0],
+  genreId: ['ds:5', 0, 12, 13, 0, 2],
+  familyGenre: ['ds:5', 0, 12, 13, 1, 0],
+  familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
+  icon: ['ds:5', 0, 12, 1, 3, 2],
+  headerImage: ['ds:5', 0, 12, 2, 3, 2],
+  screenshots: {
+    path: ['ds:5', 0, 12, 0],
+    fun: (screenshots) => {
+      if (screenshots === null) return [];
+      return screenshots.map(R.path([3, 2]));
+    }
+  },
+  video: ['ds:5', 0, 12, 3, 0, 3, 2],
+  videoImage: ['ds:5', 0, 12, 3, 1, 3, 2],
+  contentRating: ['ds:5', 0, 12, 4, 0],
+  contentRatingDescription: ['ds:5', 0, 12, 4, 2, 1],
+  adSupported: {
+    path: ['ds:5', 0, 12, 14, 0],
+    fun: Boolean
+  },
+  released: ['ds:5', 0, 12, 36],
+  updated: {
+    path: ['ds:5', 0, 12, 8, 0],
+    fun: (ts) => ts * 1000
+  },
+  version: ['ds:8', 1],
+  recentChanges: ['ds:5', 0, 12, 6, 1],
+  comments: {
+    path: ['ds:17', 0],
+    fun: extractComments
+  },
+  editorsChoice: {
+    path: ['ds:5', 0, 12, 15, 0],
+    fun: Boolean
+  }
+};
+
+function descriptionText (description) {
+  // preserve the line breaks when converting to text
+  const html = cheerio.load('<div>' + description.replace(/<br>/g, '\r\n') + '</div>');
+  return cheerio.text(html('div'));
+}
+
+function priceText (priceText) {
+  return priceText || 'Free';
+}
+
+function normalizeAndroidVersion (androidVersionText) {
+  const number = androidVersionText.split(' ')[0];
+  if (parseFloat(number)) {
+    return number;
+  }
+  return 'VARY';
+}
+
+function buildHistogram (container) {
+  if (!container) {
+    return { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  }
+  return {
+    1: container[1][1],
+    2: container[2][1],
+    3: container[3][1],
+    4: container[4][1],
+    5: container[5][1]
+  };
+}
+
+function extractComments (comments) {
+  if (!comments) {
+    return [];
+  }
+
+  debug('comments: %O', comments);
+
+  return R.compose(
+    R.take(5),
+    R.reject(R.isNil),
+    R.pluck(4))(comments);
+}
+
+module.exports = MAPPINGS;

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -31,7 +31,7 @@ function extractor (mappings) {
 function parse (response) {
   const scriptRegex = />AF_initDataCallback[\s\S]*?<\/script/g;
   const keyRegex = /(ds:.*?)'/;
-  const valueRegex = /return ([\s\S]*?)}}\);<\//;
+  const valueRegex = /data:([\s\S]*?)}\);<\//;
 
   const matches = response.match(scriptRegex);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "scrapes app data from google play store",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --timeout 5000"
+    "test": "mocha --timeout 5000",
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -10,7 +10,7 @@ describe('App method', () => {
     return gplay.app({ appId: 'com.sgn.pandapop.gp' })
       .then((app) => {
         assert.equal(app.appId, 'com.sgn.pandapop.gp');
-        assert.equal(app.title, 'Panda Pop! Bubble Shooter Saga | Blast Bubbles');
+        assert.equal(app.title, 'Bubble Shooter: Panda Pop!');
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=en&gl=us');
         assertValidUrl(app.icon);
 
@@ -94,7 +94,7 @@ describe('App method', () => {
     return gplay.app({ appId: 'com.sgn.pandapop.gp', lang: 'es', country: 'ar' })
       .then((app) => {
         assert.equal(app.appId, 'com.sgn.pandapop.gp');
-        assert.equal(app.title, 'Panda Pop');
+        assert.equal(app.title, 'Bubble Shooter: Panda Pop!');
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=es&gl=ar');
         assert.isNumber(app.minInstalls);
 
@@ -107,7 +107,7 @@ describe('App method', () => {
     gplay.app({ appId: 'com.sgn.pandapop.gp', lang: 'fr', country: 'fr' })
       .then((app) => {
         assert.equal(app.appId, 'com.sgn.pandapop.gp');
-        assert.equal(app.title, 'Panda Pop');
+        assert.equal(app.title, 'Bubble Shooter: Panda Pop!');
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=fr&gl=fr');
         assert.isNumber(app.minInstalls);
 


### PR DESCRIPTION
This PR fixes the following issues:
#407 

I have updated the following methods:
`.app`

Google Play store changed the way that the script `AF_initDataCallback` is handled.
I have updated the regex to match the new script.

I've also updated the tests and docs, refactored the mapping for app details, and included a new field `maxInstalls`