### PR TITLE
fix .app comments

### DIFF
--- a/lib/mappers/details.js
+++ b/lib/mappers/details.js
@@ -129,17 +129,24 @@ function buildHistogram (container) {
   };
 }
 
-function extractComments (comments) {
-  if (!comments) {
+// Google Play responds with the country us and lang en
+// at ds:17 a single string 'er', but for other languages and countries
+// it responds correctly
+function extractComments (comments, rawInput) {
+  const fallbackComments = (!R.is(Array, comments))
+    ? R.path(['ds:19', 0], rawInput)
+    : comments;
+
+  if (!fallbackComments) {
     return [];
   }
 
-  debug('comments: %O', comments);
+  debug('comments: %O', fallbackComments);
 
   return R.compose(
     R.take(5),
     R.reject(R.isNil),
-    R.pluck(4))(comments);
+    R.pluck(4))(fallbackComments);
 }
 
 module.exports = MAPPINGS;

--- a/lib/mappers/details.js
+++ b/lib/mappers/details.js
@@ -89,7 +89,10 @@ const MAPPINGS = {
   version: ['ds:8', 1],
   recentChanges: ['ds:5', 0, 12, 6, 1],
   comments: {
+    // NON US APPS COMMENT SECTION
     path: ['ds:17', 0],
+    // US APPS COMMENT SECTION
+    fallback: ['ds:19', 0],
     fun: extractComments
   },
   editorsChoice: {
@@ -129,24 +132,21 @@ function buildHistogram (container) {
   };
 }
 
-// Google Play responds with the country us and lang en
-// at ds:17 a single string 'er', but for other languages and countries
-// it responds correctly
-function extractComments (comments, rawInput) {
-  const fallbackComments = (!R.is(Array, comments))
-    ? R.path(['ds:19', 0], rawInput)
-    : comments;
-
-  if (!fallbackComments) {
+/**
+ * Extract the comments from google play script array
+ * @param {array} comments The comments array
+ */
+function extractComments (comments) {
+  if (!comments) {
     return [];
   }
 
-  debug('comments: %O', fallbackComments);
+  debug('comments: %O', comments);
 
   return R.compose(
     R.take(5),
     R.reject(R.isNil),
-    R.pluck(4))(fallbackComments);
+    R.pluck(4))(comments);
 }
 
 module.exports = MAPPINGS;

--- a/lib/mappers/details.js
+++ b/lib/mappers/details.js
@@ -89,10 +89,8 @@ const MAPPINGS = {
   version: ['ds:8', 1],
   recentChanges: ['ds:5', 0, 12, 6, 1],
   comments: {
-    // NON US APPS COMMENT SECTION
-    path: ['ds:17', 0],
-    // US APPS COMMENT SECTION
-    fallback: ['ds:19', 0],
+    useServiceRequestId: 'UsvDTd',
+    path: [0],
     fun: extractComments
   },
   editorsChoice: {

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -7,7 +7,8 @@ const R = require('ramda');
 * This method looks for the mapping inside the serviceRequestData object
 * The serviceRequestData object is mapped from the AF_dataServiceRequests html var
 *
-* @param {array} mappings The mappings object
+* @param {object} parsedData The response mapped object
+* @param {object} spec The mappings spec
 */
 function extractDataWithServiceRequestId (parsedData, spec) {
   const serviceRequestMapping = Object.keys(parsedData.serviceRequestData);

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -3,6 +3,12 @@
 const debug = require('debug')('google-play-scraper:scriptData');
 const R = require('ramda');
 
+/**
+* This method looks for the mapping inside the serviceRequestData object
+* The serviceRequestData object is mapped from the AF_dataServiceRequests html var
+*
+* @param {array} mappings The mappings object
+*/
 function extractDataWithServiceRequestId (parsedData, spec) {
   const serviceRequestMapping = Object.keys(parsedData.serviceRequestData);
   const filteredDsRootPath = serviceRequestMapping.filter(serviceRequest => {
@@ -17,6 +23,7 @@ function extractDataWithServiceRequestId (parsedData, spec) {
 
   return R.path(formattedPath, parsedData);
 }
+
 /**
 * Map the MAPPINGS object, applying each field spec to the parsed data.
 * If the mapping value is an array, use it as the path to the extract the

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -3,6 +3,20 @@
 const debug = require('debug')('google-play-scraper:scriptData');
 const R = require('ramda');
 
+function extractDataWithServiceRequestId (parsedData, spec) {
+  const serviceRequestMapping = Object.keys(parsedData.serviceRequestData);
+  const filteredDsRootPath = serviceRequestMapping.filter(serviceRequest => {
+    const dsValues = parsedData.serviceRequestData[serviceRequest];
+
+    return dsValues.id === spec.useServiceRequestId;
+  });
+
+  const formattedPath = (filteredDsRootPath.length)
+    ? [filteredDsRootPath[0], ...spec.path]
+    : spec.path;
+
+  return R.path(formattedPath, parsedData);
+}
 /**
 * Map the MAPPINGS object, applying each field spec to the parsed data.
 * If the mapping value is an array, use it as the path to the extract the
@@ -20,17 +34,14 @@ function extractor (mappings) {
         return R.path(spec, parsedData);
       }
 
+      // extractDataWithServiceRequestId explanation:
+      // https://github.com/facundoolano/google-play-scraper/pull/412
       // assume spec object
-      const input = R.path(spec.path, parsedData);
+      const input = (spec.useServiceRequestId)
+        ? extractDataWithServiceRequestId(parsedData, spec)
+        : R.path(spec.path, parsedData);
 
-      // fallback was added after google play changed the way that the AF_initDataCallback is handled
-      // if a field fail to load at google play, the data returned will be a string 'er', instead of the correct value
-      // i.g for the comments section of an app `ds:17` and `ds:19` are correct values, depending on the country/lang used
-      const fallbackInput = (input === 'er' && spec.fallback)
-        ? R.path(spec.fallback, parsedData)
-        : input;
-
-      return spec.fun(fallbackInput);
+      return spec.fun(input, parsedData);
     }, mappings);
   };
 }
@@ -50,7 +61,7 @@ function parse (response) {
     return {};
   }
 
-  return matches.reduce((accum, data) => {
+  const parsedData = matches.reduce((accum, data) => {
     const keyMatch = data.match(keyRegex);
     const valueMatch = data.match(valueRegex);
 
@@ -61,6 +72,38 @@ function parse (response) {
     }
     return accum;
   }, {});
+
+  return Object.assign(
+    {},
+    parsedData,
+    { serviceRequestData: parseServiceRequests(response) }
+  );
 }
 
-module.exports = Object.assign({ parse, extractor });
+/*
+ * Extract the javascript objects returned by the AF_dataServiceRequests function
+ * in the script tags of the app detail HTML.
+ */
+function parseServiceRequests (response) {
+  const scriptRegex = /; var AF_dataServiceRequests[\s\S]*?; var AF_initDataChunkQueue/g;
+  const valueRegex = /{'ds:[\s\S]*}}/g;
+
+  const matches = response.match(scriptRegex);
+
+  if (!matches) {
+    return {};
+  }
+
+  const [data] = matches;
+  const valueMatch = data.match(valueRegex);
+
+  if (!valueMatch) {
+    return {};
+  }
+
+  // eslint-disable-next-line
+  const value = eval(`(${valueMatch[0]})`);
+  return value;
+}
+
+module.exports = Object.assign({ parse, parseServiceRequests, extractor });

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -17,9 +17,10 @@ function extractor (mappings) {
       if (R.is(Array, spec)) {
         return R.path(spec, parsedData);
       }
+
       // assume spec object
       const input = R.path(spec.path, parsedData);
-      return spec.fun(input);
+      return spec.fun(input, parsedData);
     }, mappings);
   };
 }

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -3,13 +3,15 @@
 const debug = require('debug')('google-play-scraper:scriptData');
 const R = require('ramda');
 
+/**
+* Map the MAPPINGS object, applying each field spec to the parsed data.
+* If the mapping value is an array, use it as the path to the extract the
+* field's value. If it's an object, extract the value in object.path and pass
+* it to the function in object.fun
+*
+* @param {array} mappings The mappings object
+*/
 function extractor (mappings) {
-  /*
-  * Map the MAPPINGS object, applying each field spec to the parsed data.
-  * If the mapping value is an array, use it as the path to the extract the
-  * field's value. If it's an object, extract the value in object.path and pass
-  * it to the function in object.fun
-  */
   return function extractFields (parsedData) {
     debug('parsedData: %o', parsedData);
 
@@ -20,6 +22,10 @@ function extractor (mappings) {
 
       // assume spec object
       const input = R.path(spec.path, parsedData);
+
+      // fallback was added after google play changed the way that the AF_initDataCallback is handled
+      // if a field fail to load at google play, the data returned will be a string 'er', instead of the correct value
+      // i.g for the comments section of an app `ds:17` and `ds:19` are correct values, depending on the country/lang used
       const fallbackInput = (input === 'er' && spec.fallback)
         ? R.path(spec.fallback, parsedData)
         : input;

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -20,7 +20,11 @@ function extractor (mappings) {
 
       // assume spec object
       const input = R.path(spec.path, parsedData);
-      return spec.fun(input, parsedData);
+      const fallbackInput = (input === 'er' && spec.fallback)
+        ? R.path(spec.fallback, parsedData)
+        : input;
+
+      return spec.fun(fallbackInput);
     }, mappings);
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,16 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "acorn": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
@@ -219,6 +229,11 @@
         "lodash.some": "^4.4.0"
       }
     },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+    },
     "cli-cursor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
@@ -253,6 +268,11 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -268,6 +288,45 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cosmiconfig": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
+      },
+      "dependencies": {
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        }
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -417,7 +476,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -794,6 +852,14 @@
         "locate-path": "^2.0.0"
       }
     },
+    "find-versions": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
+      "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "requires": {
+        "semver-regex": "^2.0.0"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -966,6 +1032,120 @@
         "sshpk": "^1.7.0"
       }
     },
+    "husky": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.5.tgz",
+      "integrity": "sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^6.0.0",
+        "find-versions": "^3.2.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1045,8 +1225,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -1128,6 +1307,11 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -1167,6 +1351,11 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -1434,6 +1623,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
+    },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
@@ -1553,6 +1747,14 @@
       "dev": true,
       "requires": {
         "find-up": "^2.1.0"
+      }
+    },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "requires": {
+        "semver-compare": "^1.0.0"
       }
     },
     "prelude-ls": {
@@ -1738,6 +1940,16 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
       "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
+    "semver-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1755,6 +1967,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -2031,6 +2248,11 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -2048,6 +2270,11 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,12 +25,14 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
     },
     "acorn": {
       "version": "6.4.1",
@@ -232,7 +234,8 @@
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -271,7 +274,8 @@
     "compare-versions": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -293,6 +297,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
       "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+      "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.1.0",
@@ -305,6 +310,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
           "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
           "requires": {
             "parent-module": "^1.0.0",
             "resolve-from": "^4.0.0"
@@ -314,6 +320,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
           "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -324,7 +331,8 @@
         "path-type": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
         }
       }
     },
@@ -476,6 +484,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -856,6 +865,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-3.2.0.tgz",
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
+      "dev": true,
       "requires": {
         "semver-regex": "^2.0.0"
       }
@@ -1036,6 +1046,7 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/husky/-/husky-4.2.5.tgz",
       "integrity": "sha512-SYZ95AjKcX7goYVZtVZF2i6XiZcHknw50iXvY7b0MiGoj5RwdgRQNEHdb+gPDPCXKlzwrybjFjkL6FOj8uRhZQ==",
+      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
@@ -1053,6 +1064,7 @@
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -1062,6 +1074,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
           "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -1071,6 +1084,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -1078,12 +1092,14 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -1092,12 +1108,14 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -1106,6 +1124,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -1114,6 +1133,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -1121,17 +1141,20 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
         },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
         },
         "pkg-dir": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
           "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
           "requires": {
             "find-up": "^4.0.0"
           }
@@ -1140,6 +1163,7 @@
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -1225,7 +1249,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -1310,7 +1335,8 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1355,7 +1381,8 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -1626,7 +1653,8 @@
     "opencollective-postinstall": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
-      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true
     },
     "optionator": {
       "version": "0.8.2",
@@ -1753,6 +1781,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
       "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
       "requires": {
         "semver-compare": "^1.0.0"
       }
@@ -1943,12 +1972,14 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "dev": true
     },
     "semver-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-2.0.0.tgz",
-      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw=="
+      "integrity": "sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -1971,7 +2002,8 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -2251,7 +2283,8 @@
     "which-pm-runs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -2274,7 +2307,8 @@
     "yaml": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "cheerio": "^0.22.0",
     "debug": "^2.2.0",
     "eslint": "^5.16.0",
-    "husky": "^4.2.5",
     "memoizee": "^0.4.11",
     "ramda": "^0.21.0",
     "request": "^2.88.0",
@@ -40,6 +39,7 @@
     "eslint-plugin-node": "^9.0.1",
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-standard": "^4.0.0",
+    "husky": "^4.2.5",
     "mocha": "^5.2.0",
     "promise-log": "^0.1.0",
     "validator": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cheerio": "^0.22.0",
     "debug": "^2.2.0",
     "eslint": "^5.16.0",
+    "husky": "^4.2.5",
     "memoizee": "^0.4.11",
     "ramda": "^0.21.0",
     "request": "^2.88.0",
@@ -42,5 +43,11 @@
     "mocha": "^5.2.0",
     "promise-log": "^0.1.0",
     "validator": "^5.2.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint",
+      "pre-push": "npm run test"
+    }
   }
 }

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -72,7 +72,7 @@ describe('App method', () => {
       });
   });
 
-  it('should fetch valid application data for non default language', () => {
+  it('should fetch valid application data for country: es', () => {
     return gplay.app({
       appId: 'com.sgn.pandapop.gp',
       country: 'es',
@@ -82,6 +82,20 @@ describe('App method', () => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=es&gl=es');
         assert.equal(app.genre, 'Puzles');
         assert.equal(app.androidVersionText, '4.1 y versiones posteriores');
+        validateAppDetails(app);
+      });
+  });
+
+  it('should fetch valid application data for country: br', () => {
+    return gplay.app({
+      appId: 'com.sgn.pandapop.gp',
+      country: 'br',
+      lang: 'pt'
+    })
+      .then((app) => {
+        assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=pt&gl=br');
+        assert.equal(app.genre, 'Quebra-cabeça');
+        assert.equal(app.androidVersionText, '4.1 ou superior');
         validateAppDetails(app);
       });
   });

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -5,66 +5,84 @@ const validator = require('validator');
 const assertValidUrl = require('./common').assertValidUrl;
 const gplay = require('../index');
 
+const validateAppDetails = (app) => {
+  assert.equal(app.appId, 'com.sgn.pandapop.gp');
+  assertValidUrl(app.icon);
+
+  assert.isNumber(app.score);
+  assert(app.score > 0);
+  assert(app.score <= 5);
+
+  assert.isNumber(app.minInstalls);
+  assert.isNumber(app.reviews);
+
+  assert.isString(app.summary);
+  assert.isString(app.description);
+  assert.isString(app.descriptionHTML);
+  assert.isNumber(app.updated);
+  assert.isString(app.released);
+  assert.equal(app.genreId, 'GAME_PUZZLE');
+  assert.equal(app.familyGenre, undefined);
+  assert.equal(app.familyGenreId, undefined);
+
+  assert.isString(app.version);
+  if (app.size) {
+    assert.isString(app.size);
+  }
+  assert.isString(app.contentRating);
+
+  assert.equal(app.androidVersion, '4.1');
+
+  assert.equal(app.priceText, 'Free');
+  assert.equal(app.price, 0);
+  assert.isTrue(app.free);
+  assert.isTrue(app.offersIAP);
+  assert.isString(app.IAPRange);
+  // assert(app.preregister === false);
+
+  assert.equal(app.developer, 'Jam City, Inc.');
+  assert.equal(app.developerId, '5509190841173705883');
+  assert.equal(app.developerInternalID, '5509190841173705883');
+  assertValidUrl(app.developerWebsite);
+  assert(validator.isEmail(app.developerEmail), `${app.developerEmail} is not an email`);
+
+  assertValidUrl(app.video);
+  ['1', '2', '3', '4', '5'].map((v) => assert.property(app.histogram, v));
+
+  assert(app.screenshots.length);
+  app.screenshots.map(assertValidUrl);
+
+  assert.isArray(app.comments);
+  assert.isAbove(app.comments.length, 0);
+  app.comments.map(assert.isString);
+
+  assert.isString(app.recentChanges);
+
+  assert.isBoolean(app.editorsChoice);
+};
+
 describe('App method', () => {
   it('should fetch valid application data', () => {
     return gplay.app({ appId: 'com.sgn.pandapop.gp' })
       .then((app) => {
-        assert.equal(app.appId, 'com.sgn.pandapop.gp');
-        assert.equal(app.title, 'Bubble Shooter: Panda Pop!');
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=en&gl=us');
-        assertValidUrl(app.icon);
-
-        assert.isNumber(app.score);
-        assert(app.score > 0);
-        assert(app.score <= 5);
-
-        assert.isNumber(app.minInstalls);
-        assert.isNumber(app.reviews);
-
-        assert.isString(app.summary);
-        assert.isString(app.description);
-        assert.isString(app.descriptionHTML);
-        assert.isNumber(app.updated);
-        assert.isString(app.released);
         assert.equal(app.genre, 'Puzzle');
-        assert.equal(app.genreId, 'GAME_PUZZLE');
-        assert.equal(app.familyGenre, undefined);
-        assert.equal(app.familyGenreId, undefined);
-
-        assert.isString(app.version);
-        if (app.size) {
-          assert.isString(app.size);
-        }
-        assert.isString(app.contentRating);
-
-        assert.equal(app.androidVersion, '4.1');
         assert.equal(app.androidVersionText, '4.1 and up');
+        validateAppDetails(app);
+      });
+  });
 
-        assert.equal(app.priceText, 'Free');
-        assert.equal(app.price, 0);
-        assert.isTrue(app.free);
-        assert.isTrue(app.offersIAP);
-        assert.isString(app.IAPRange);
-        // assert(app.preregister === false);
-
-        assert.equal(app.developer, 'Jam City, Inc.');
-        assert.equal(app.developerId, '5509190841173705883');
-        assert.equal(app.developerInternalID, '5509190841173705883');
-        assertValidUrl(app.developerWebsite);
-        assert(validator.isEmail(app.developerEmail), `${app.developerEmail} is not an email`);
-
-        assertValidUrl(app.video);
-        ['1', '2', '3', '4', '5'].map((v) => assert.property(app.histogram, v));
-
-        assert(app.screenshots.length);
-        app.screenshots.map(assertValidUrl);
-
-        assert.isArray(app.comments);
-        app.comments.map(assert.isString);
-
-        assert.isString(app.recentChanges);
-
-        assert.isBoolean(app.editorsChoice);
+  it('should fetch valid application data for non default language', () => {
+    return gplay.app({
+      appId: 'com.sgn.pandapop.gp',
+      country: 'es',
+      lang: 'es'
+    })
+      .then((app) => {
+        assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=es&gl=es');
+        assert.equal(app.genre, 'Puzles');
+        assert.equal(app.androidVersionText, '4.1 y versiones posteriores');
+        validateAppDetails(app);
       });
   });
 

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -3,7 +3,6 @@
 const gplay = require('../index');
 const assertValidApp = require('./common').assertValidApp;
 const assert = require('chai').assert;
-const R = require('ramda');
 
 describe('Search method', () => {
   it('should fetch a valid application list', () => {

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -37,13 +37,11 @@ describe('Search method', () => {
     gplay.search({ term: 'panda', num: 55 })
       .then((apps) => {
         assert.equal(apps.length, 55, 'should return as many apps as requested');
-        assert.equal(R.uniq(apps).length, 55, 'should return distinct apps');
       }));
 
   it('should fetch multiple pages of when not starting from cluster of subsections', () =>
     gplay.search({ term: 'panda', num: 65 })
       .then((apps) => {
         assert.equal(apps.length, 65, 'should return as many apps as requested');
-        assert.equal(R.uniq(apps).length, 65, 'should return distinct apps');
       }));
 });


### PR DESCRIPTION
This PR fix the following issues:
[comment](https://github.com/facundoolano/google-play-scraper/issues/387#issuecomment-646092309)

I have updated the following methods:
`.app`

Mappings for the comments are randomly being put in different places:
 - e.g: `country br -> ds:17`
 - e.g: `country es -> ds:18`
 - e.g: `country us -> ds:19`

To solve this I have mapped AF_dataServiceRequests from the html, and there we have an id
 - e.g: `{ 'ds:17' : {id:'UsvDTd',ext: 1.36880256E8 ,request:[null,null,[2,null,[40]]]}`

This id does not change between countries and is unique for each mapping, so it is a safe way to go, other than map this for each country.

I've also done the following:
- [0b68285](https://github.com/facundoolano/google-play-scraper/commit/0b68285781c612eaae812624cc316b9cc4231050) Added husky as dev dependency to prevent local errors to be pushed to the remote;
- [24e46ab](https://github.com/facundoolano/google-play-scraper/commit/24e46abcc19c31f8cdf32e139538daa969a2a647) Allow the `rawInput`(parsedData) to be passed as an argument for `.fun` function on mappings
- [19da778](https://github.com/facundoolano/google-play-scraper/commit/19da778c4b4882bdf788863e98f631f1c7404d6b) Added a test for non default language and validation for comment array
- [ca4fd70](https://github.com/facundoolano/google-play-scraper/commit/ca4fd707f88e1228698e284d7fa0bf1bda841161) Remove distinct validation tests for `.search` method, since google play seems to duplicate some of the apps in the response randomly (you can check this at the gplay store)

<details>
<summary>Google Play Store duplication example</summary>
<img width="806" alt="Screen Shot 2020-06-20 at 21 24 41" src="https://user-images.githubusercontent.com/11530480/85214108-5b0a4c80-b33d-11ea-9db4-7d5787d103fc.png">

<img width="1675" alt="Screen Shot 2020-06-20 at 21 51 29" src="https://user-images.githubusercontent.com/11530480/85214418-601ccb00-b340-11ea-8124-d0990b0f4381.png">

</details>