### PR TITLE
restore pagination for .reviews method

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,69 +269,109 @@ Retrieves a page of reviews for a specific application.
 
 Note that this method returns reviews in a specific language (english by default), so you need to try different languages to get more reviews. Also, the counter displayed in the Google Play page refers to the total number of 1-5 stars ratings the application has, not the written reviews count. So if the app has 100k ratings, don't expect to get 100k reviews by using this method.
 
+You can get all reviews at once, by sending the `num` parameter (i.g. 5000), or paginated reviews (with 150 per page), by setting the `pagination` parameter to true;
+
+You`ll have to choose wich method is better for your use case.
+
+By setting `num` + `paginate`, the num parameter will be ignored and you will receive a paginated response instead.
+
 Options:
 
 * `appId`: Unique application id for Google Play. (e.g. id=com.mojang.minecraftpe maps to Minecraft: Pocket Edition game).
 * `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the reviews.
 * `country` (optional, defaults to `'us'`): the two letter country code in which to fetch the reviews.
 * `sort` (optional, defaults to `sort.NEWEST`): The way the reviews are going to be sorted. Accepted values are: `sort.NEWEST`, `sort.RATING` and `sort.HELPFULNESS`.
-* `num` (optional, defaults to 100): Quantity of reviews to be captured.
+* `num` (optional, defaults to `100`): Quantity of reviews to be captured.
+* `paginate` (optional, defaults to `false`): Defines if the result will be paginated
+* `nextPaginationToken` (optional, defaults to `null`): The next token to paginate
 
 Example:
 
 ```javascript
 var gplay = require('google-play-scraper');
 
+// This example will return 3000 reviews
+// on a single call
 gplay.reviews({
   appId: 'com.mojang.minecraftpe',
-  sort: gplay.sort.RATING
+  sort: gplay.sort.RATING,
+  num: 3000
+}).then(console.log, console.log);
+
+// This example will return the first page with 150 reviews paginated
+// just send an empty nexPaginationToken
+// you will receive a nextPaginationToken parameter in your response
+gplay.reviews({
+  appId: 'com.mojang.minecraftpe',
+  sort: gplay.sort.RATING,
+  paginate: true,
+  nextPaginationToken: null // you can omit this parameter
+}).then(console.log, console.log);
+
+// This example will return 150 reviews paginated
+// for the next page (next page is the token return by the previous call)
+// you will receive a nextPaginationToken parameter in your response
+gplay.reviews({
+  appId: 'com.mojang.minecraftpe',
+  sort: gplay.sort.RATING,
+  paginate: true,
+  nextPaginationToken: 'TOKEN_FROM_THE_PREVIOUS_REQUEST' // you can omit this parameter
 }).then(console.log, console.log);
 ```
 
 Results:
 
 ```javascript
-[ { id: 'gp:AOqpTOFmAVORqfWGcaqfF39ftwFjGkjecjvjXnC3g_uL0NtVGlrrqm8X2XUWx0WydH3C9afZlPUizYVZAfARLuk',
-    userName: 'Inga El-Ansary',
-    userImage: 'https://lh3.googleusercontent.com/-hBGvzn3XlhQ/AAAAAAAAAAI/AAAAAAAAOw0/L4GY9KrQ-DU/w96-c-h96/photo.jpg',
-    date: '2013-11-10T18:31:42.174Z',
-    score: 5,
-    scoreText: '5',
-    url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRWZaVHVZZ081NlNsRW9TV0hJeklGSTBvYTBTUlFQUUJIZThBSGJDX2s1Y1o0ZXRCbUtLZmgzTE1PMUttRmpRSS1YcFgxRmx1ZXNtVzlVS0Zz'
-    title: 'I LOVE IT',
-    text: 'It has skins and snowballs everything I wanted its so cool I love it!!!!!!!!',
-    replyDate: '2013-11-10T18:31:42.174Z',
-    replyText: 'thanks for playing Panda vs Zombies!',
-    version: '1.0.2',
-    thumbsUp: 29,
-    criterias: [
-      {
-        criteria: 'vaf_games_simple',
-        rating: 1
-      },
-      {
-        criteria: 'vaf_games_realistic',
-        rating: 1
-      },
-      {
-        criteria: 'vaf_games_complex',
-        rating: 1
-      }
-    ] },
-{   id: 'gp:AOqpTOF39mpW-6gurlkCCTV_8qnKne7O5wcFsLc6iGVot5hHpplqPCqIiVL2fjximXNujuMjwQ4pkizxGrn13x0',
-    userName: 'Millie Hawthorne',
-    userImage: 'https://lh5.googleusercontent.com/-Q_FTAEBH2Qg/AAAAAAAAAAI/AAAAAAAAAZk/W5dTdaHCUE4/w96-c-h96/photo.jpg',
-    date: '2013-11-10T18:31:42.174Z',
-    url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRmFHdlBFS2pGS2JVYW5Dd3kxTm1qUzRxQlYyc3Z4ZE9CYXRuc0hkclV3a09hbEFkOVdoWmw3eFN5VjF4cDJPLTg5TW5ZUjl1Zm9HOWc5NGtr',
-    score: 5,
-    scoreText: '5',
-    title: 'CAN NEVER WAIT TILL NEW UPDATE',
-    text: 'Love it but needs to pay more attention to pocket edition',
-    replyDate: null,
-    replyText: null,
-    version: null,
-    thumbsUp: 29
-    criterias: [] } ]
+{
+  data: [
+    {
+      id: 'gp:AOqpTOFmAVORqfWGcaqfF39ftwFjGkjecjvjXnC3g_uL0NtVGlrrqm8X2XUWx0WydH3C9afZlPUizYVZAfARLuk',
+      userName: 'Inga El-Ansary',
+      userImage: 'https://lh3.googleusercontent.com/-hBGvzn3XlhQ/AAAAAAAAAAI/AAAAAAAAOw0/L4GY9KrQ-DU/w96-c-h96/photo.jpg',
+      date: '2013-11-10T18:31:42.174Z',
+      score: 5,
+      scoreText: '5',
+      url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRWZaVHVZZ081NlNsRW9TV0hJeklGSTBvYTBTUlFQUUJIZThBSGJDX2s1Y1o0ZXRCbUtLZmgzTE1PMUttRmpRSS1YcFgxRmx1ZXNtVzlVS0Zz'
+      title: 'I LOVE IT',
+      text: 'It has skins and snowballs everything I wanted its so cool I love it!!!!!!!!',
+      replyDate: '2013-11-10T18:31:42.174Z',
+      replyText: 'thanks for playing Panda vs Zombies!',
+      version: '1.0.2',
+      thumbsUp: 29,
+      criterias: [
+        {
+          criteria: 'vaf_games_simple',
+          rating: 1
+        },
+        {
+          criteria: 'vaf_games_realistic',
+          rating: 1
+        },
+        {
+          criteria: 'vaf_games_complex',
+          rating: 1
+        }
+      ]
+    },
+    {
+      id: 'gp:AOqpTOF39mpW-6gurlkCCTV_8qnKne7O5wcFsLc6iGVot5hHpplqPCqIiVL2fjximXNujuMjwQ4pkizxGrn13x0',
+      userName: 'Millie Hawthorne',
+      userImage: 'https://lh5.googleusercontent.com/-Q_FTAEBH2Qg/AAAAAAAAAAI/AAAAAAAAAZk/W5dTdaHCUE4/w96-c-h96/photo.jpg',
+      date: '2013-11-10T18:31:42.174Z',
+      url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRmFHdlBFS2pGS2JVYW5Dd3kxTm1qUzRxQlYyc3Z4ZE9CYXRuc0hkclV3a09hbEFkOVdoWmw3eFN5VjF4cDJPLTg5TW5ZUjl1Zm9HOWc5NGtr',
+      score: 5,
+      scoreText: '5',
+      title: 'CAN NEVER WAIT TILL NEW UPDATE',
+      text: 'Love it but needs to pay more attention to pocket edition',
+      replyDate: null,
+      replyText: null,
+      version: null,
+      thumbsUp: 29
+      criterias: []
+    }
+  ],
+  nextPaginationToken: 'NEXT_PAGINATION_TOKEN'
+}
 ```
 
 ### similar

--- a/index.d.ts
+++ b/index.d.ts
@@ -255,7 +255,9 @@ export interface IFnReviewsOptions extends IOptions {
   lang?: string
   country?: string
   sort?: sort
-  num?: number
+  num?: number,
+  paginate?: boolean
+  nextPaginationToken?: string
 }
 
 export interface IFnReviews {

--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -9,6 +9,26 @@ const { REQUEST_MAPPINGS } = require('../mappers/reviews');
 const { BASE_URL } = require('../utils/configurations');
 
 /**
+ * Format the reviews for correct and unified response model
+ * @param {array} reviews The reviews to be formated
+ * @param {string} token The token to be sent
+ */
+function formatReviewsResponse ({
+  reviews,
+  num,
+  token = null
+}) {
+  const reviewsToResponse = (reviews.length >= num)
+    ? reviews.slice(0, num)
+    : reviews;
+
+  return {
+    data: reviewsToResponse,
+    nextPaginationToken: token
+  };
+}
+
+/**
  * This object allow us to differ between
  * the initial body request and the paginated ones
  */
@@ -20,16 +40,16 @@ const REQUEST_TYPE = {
 /**
  * This method allow us to get the body for the review request
  *
- * @param options.appId The app id for reviews
- * @param options.sort The sort order for reviews
- * @param options.numberOfReviewsPerRequest The number of reviews per request
- * @param options.withToken The token to be used for the given request
- * @param options.requestType The
+ * @param {string} options.appId The app id for reviews
+ * @param {number} options.sort The sort order for reviews
+ * @param {number} options.numberOfReviewsPerRequest The number of reviews per request
+ * @param {string} options.withToken The token to be used for the given request
+ * @param {string} options.requestType The request type
  */
 function getBodyForRequests ({
   appId,
   sort,
-  numberOfReviewsPerRequest = 100,
+  numberOfReviewsPerRequest = 150,
   withToken = '%token%',
   requestType = REQUEST_TYPE.initial
 }) {
@@ -42,43 +62,59 @@ function getBodyForRequests ({
   return formBody[requestType];
 }
 
-async function processAndRecur (html, opts, savedReviews, mappings) {
-  if (R.is(String, html)) {
-    html = scriptData.parse(html);
+async function processReviewsAndGetNextPage (html, opts, savedReviews) {
+  const processAndRecurOptions = Object.assign({}, opts, { requestType: REQUEST_TYPE.paginated });
+  const { appId, paginate, num } = processAndRecurOptions;
+  const parsedHtml = R.is(String, html)
+    ? scriptData.parse(html)
+    : html;
+
+  if (parsedHtml.length === 0) {
+    return formatReviewsResponse(savedReviews);
   }
 
-  if (html.length === 0) {
-    return savedReviews;
-  }
+  // PROCESS REVIEWS EXTRACTION
+  const reviews = reviewsList.extract(REQUEST_MAPPINGS.reviews, parsedHtml, appId);
+  const token = R.path(REQUEST_MAPPINGS.token, parsedHtml);
+  const reviewsAccumulator = [...savedReviews, ...reviews];
 
-  const reviews = reviewsList.extract(mappings.reviews, html, opts.appId);
-  const token = R.path(mappings.token, html);
-  opts.requestType = REQUEST_TYPE.paginated;
-
-  return checkFinished(opts, [...savedReviews, ...reviews], token);
+  return (!paginate && token)
+    ? makeReviewsRequest(processAndRecurOptions, reviewsAccumulator, token)
+    : formatReviewsResponse({ reviews, token, num });
 }
 
-function checkFinished (opts, savedReviews, nextToken) {
+/**
+ * Make a review request to Google Play Store
+ * @param {object} opts The request options
+ * @param {array} savedReviews The reviews accumulator array
+ * @param {string} nextToken The next page token
+ */
+function makeReviewsRequest (opts, savedReviews, nextToken) {
   debug('nextToken: %s', nextToken);
   debug('savedReviews length: %s', savedReviews.length);
   debug('requestType: %s', opts.requestType);
 
-  if (savedReviews.length >= opts.num || !nextToken) {
-    return savedReviews.slice(0, opts.num);
-  }
-
+  const {
+    appId,
+    sort,
+    requestType,
+    lang,
+    country,
+    requestOptions,
+    throttle
+  } = opts;
   const body = getBodyForRequests({
-    appId: opts.appId,
-    sort: opts.sort,
+    appId,
+    sort,
     withToken: nextToken,
-    requestType: opts.requestType
+    requestType
   });
-  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&gl=${opts.country}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
+  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${lang}&gl=${country}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
 
   debug('batchexecute URL: %s', url);
   debug('with body: %s', body);
 
-  const requestOptions = Object.assign({
+  const reviewRequestOptions = Object.assign({
     url,
     method: 'POST',
     body,
@@ -86,24 +122,33 @@ function checkFinished (opts, savedReviews, nextToken) {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
     }
-  }, opts.requestOptions);
+  }, requestOptions);
 
-  return request(requestOptions, opts.throttle)
+  return request(reviewRequestOptions, throttle)
     .then((html) => {
       const input = JSON.parse(html.substring(5));
       const data = JSON.parse(input[0][2]);
 
       return (data === null)
-        ? savedReviews
-        : processAndRecur(data, opts, savedReviews, REQUEST_MAPPINGS);
+        ? formatReviewsResponse(savedReviews)
+        : processReviewsAndGetNextPage(data, opts, savedReviews);
     });
 }
 
-function processFullReviews (opts) {
-  opts.requestType = REQUEST_TYPE.initial;
-  return checkFinished(opts, [], '%token%');
+/**
+ * Process the reviews for a given app
+ * @param {object} opts The options for reviews behavior
+ */
+function processReviews (opts) {
+  const requestType = (!opts.nextPaginationToken)
+    ? REQUEST_TYPE.initial
+    : REQUEST_TYPE.paginated;
+  const token = opts.nextPaginationToken || '%token%';
+
+  const reviewsOptions = Object.assign({}, { requestType }, opts);
+  return makeReviewsRequest(reviewsOptions, [], token);
 }
 
 module.exports = {
-  processFullReviews
+  processReviews
 };

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -2,14 +2,21 @@
 
 const R = require('ramda');
 const c = require('./constants');
-const { processFullReviews } = require('./requesters/reviewsMappedRequests');
+const { processReviews } = require('./requesters/reviewsMappedRequests');
 
 function reviews (opts) {
   return new Promise(function (resolve, reject) {
-    opts = R.clone(opts || {});
     validate(opts);
+    const fullOptions = Object.assign({
+      sort: c.sort.NEWEST,
+      lang: 'en',
+      country: 'us',
+      num: 150,
+      paginate: false,
+      nextPaginationToken: null
+    }, opts);
 
-    processFullReviews(opts)
+    processReviews(fullOptions)
       .then(resolve)
       .catch(reject);
   });
@@ -23,11 +30,6 @@ function validate (opts) {
   if (opts.sort && !R.contains(opts.sort, R.values(c.sort))) {
     throw new Error('Invalid sort ' + opts.sort);
   }
-
-  opts.sort = opts.sort || c.sort.NEWEST;
-  opts.lang = opts.lang || 'en';
-  opts.country = opts.country || 'us';
-  opts.num = opts.num || 100;
 }
 
 module.exports = reviews;

--- a/test/lib.reviews.js
+++ b/test/lib.reviews.js
@@ -31,7 +31,7 @@ describe('Reviews method', () => {
   it('should retrieve the most recent reviews of an app', () => {
     return gplay.reviews({ appId: 'com.dxco.pandavszombies' })
       .then((reviews) => {
-        reviews.map(assertValid);
+        reviews.data.map(assertValid);
       });
   });
 
@@ -41,7 +41,7 @@ describe('Reviews method', () => {
       sort: c.sort.HELPFULNESS
     })
       .then((reviews) => {
-        reviews.map(assertValid);
+        reviews.data.map(assertValid);
       });
   });
 
@@ -51,7 +51,7 @@ describe('Reviews method', () => {
       sort: c.sort.RATING
     })
       .then((reviews) => {
-        reviews.map(assertValid);
+        reviews.data.map(assertValid);
       });
   });
 
@@ -67,7 +67,41 @@ describe('Reviews method', () => {
   it('should retrieve the reviews of an app in Japanese', () => {
     return gplay.reviews({ appId: 'com.dxco.pandavszombies', lang: 'ja' })
       .then((reviews) => {
-        reviews.map(assertValid);
+        reviews.data.map(assertValid);
       });
+  });
+
+  it('should accept pagination', () => {
+    return gplay.reviews({
+      appId: 'com.facebook.katana',
+      paginate: true
+    })
+      .then((reviews) => {
+        reviews.data.map(assertValid);
+        assert.equal(reviews.data.length, 150);
+        assert.isNotNull(reviews.nextPaginationToken);
+      });
+  });
+
+  it('should get different reviews for nextPageToken', async () => {
+    const firstPageReviews = await gplay.reviews({
+      appId: 'com.facebook.katana',
+      paginate: true
+    });
+    const { data, nextPaginationToken } = firstPageReviews;
+
+    assert.equal(data.length, 150);
+    assert.isNotNull(nextPaginationToken);
+
+    const secondPageReviews = await gplay.reviews({
+      appId: 'com.facebook.katana',
+      paginate: true,
+      nextPaginationToken
+    });
+    const { data: dataSecondPage, nextPaginationToken: secondPaginationToken } = secondPageReviews;
+
+    assert.equal(dataSecondPage.length, 150);
+    assert.isNotNull(secondPaginationToken);
+    assert.notDeepEqual(data, dataSecondPage);
   });
 });


### PR DESCRIPTION
This PR add a new feature:
- pagination for `.reviews` method
- **this is a breaking change**

I have updated the following methods:
`.reviews`

This lib lost the `.reviews` pagination, due to the changes in google play, and how the reviews were handled.
There is in fact a way for this lib to accept paginations again, but different from the previous one.
A way to mimic the behaviour is:

- Set the `paginate` parameter to true (paginated responses will always have 150 reviews)
- Send the first request
- In the response you will receive the `nextPaginationToken` parameter
- Forward the `nextPaginationToken` to the next call for the `.reviews` method
- Repeat the process for as long as you want or until the `nextPaginationToken` is null

For this to work, I had to change the response for the `.reviews` method.
I have also maintained the `num` parameter for some backward compatibility