### PR TITLE
Fix .reviews method

### DIFF
--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -78,7 +78,7 @@ async function processReviewsAndGetNextPage (html, opts, savedReviews) {
   const token = R.path(REQUEST_MAPPINGS.token, parsedHtml);
   const reviewsAccumulator = [...savedReviews, ...reviews];
 
-  return (!paginate && token)
+  return (!paginate && token && reviewsAccumulator.length < opts.num)
     ? makeReviewsRequest(processAndRecurOptions, reviewsAccumulator, token)
     : formatReviewsResponse({ reviews, token, num });
 }


### PR DESCRIPTION
Let's say we need the most recent 10 reviews for the Instagram app. The .reviews method will try to load all reviews for the app (millions) then return the required 10 reviews.

This PR will stop the HTTP requests once the library has loaded the required reviews.