### PR TITLE
Fix .reviews method

### DIFF
--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -80,7 +80,7 @@ async function processReviewsAndGetNextPage (html, opts, savedReviews) {
 
   return (!paginate && token && reviewsAccumulator.length < opts.num)
     ? makeReviewsRequest(processAndRecurOptions, reviewsAccumulator, token)
-    : formatReviewsResponse({ reviews, token, num });
+    : formatReviewsResponse({ reviews: reviewsAccumulator, token, num });
 }
 
 /**


### PR DESCRIPTION
The .reviews method returns the reviews in the last page only and discard the previously fetched reviews. E.g. if we request 1000 reviews, the library will fetch +1000 reviews, but will return only 150 reviews.

This PR fixes the issue.