### PR TITLE
fix scriptData.js (store update 2020-08-26)

### DIFF
--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -61,7 +61,7 @@ function extractor (mappings) {
 function parse (response) {
   const scriptRegex = />AF_initDataCallback[\s\S]*?<\/script/g;
   const keyRegex = /(ds:.*?)'/;
-  const valueRegex = /data:([\s\S]*?)}\);<\//;
+  const valueRegex = /data:([\s\S]*?), sideChannel: {}}\);<\//;
 
   const matches = response.match(scriptRegex);
 


### PR DESCRIPTION
This PR fixes the following issues:
#429 #428 

I have updated the following file:
`scriptData.js`

Google Play store changed the way that the script AF_initDataCallback is handled **again**.
I have updated the regex to match the new script.