### PR TITLE
Fixing type issue with typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -231,7 +231,7 @@ export interface IFnDeveloperOptions extends IOptions {
   lang?: string
   country?: string
   num?: number
-  fullDetail?: false
+  fullDetail?: boolean
 }
 
 export interface IFnDeveloper {


### PR DESCRIPTION
I got the following error, after upgrading this library.
```
Type 'true' is not assignable to type 'false'.
```

It is due to a type error, I just fixed.