### PR TITLE
Fix response when app doesn't have reviews

### DIFF
--- a/lib/requesters/reviewsMappedRequests.js
+++ b/lib/requesters/reviewsMappedRequests.js
@@ -70,7 +70,7 @@ async function processReviewsAndGetNextPage (html, opts, savedReviews) {
     : html;
 
   if (parsedHtml.length === 0) {
-    return formatReviewsResponse(savedReviews);
+    return formatReviewsResponse({ reviews: savedReviews, token: null, num });
   }
 
   // PROCESS REVIEWS EXTRACTION
@@ -78,7 +78,7 @@ async function processReviewsAndGetNextPage (html, opts, savedReviews) {
   const token = R.path(REQUEST_MAPPINGS.token, parsedHtml);
   const reviewsAccumulator = [...savedReviews, ...reviews];
 
-  return (!paginate && token && reviewsAccumulator.length < opts.num)
+  return (!paginate && token && reviewsAccumulator.length < num)
     ? makeReviewsRequest(processAndRecurOptions, reviewsAccumulator, token)
     : formatReviewsResponse({ reviews: reviewsAccumulator, token, num });
 }
@@ -101,7 +101,8 @@ function makeReviewsRequest (opts, savedReviews, nextToken) {
     lang,
     country,
     requestOptions,
-    throttle
+    throttle,
+    num
   } = opts;
   const body = getBodyForRequests({
     appId,
@@ -130,7 +131,7 @@ function makeReviewsRequest (opts, savedReviews, nextToken) {
       const data = JSON.parse(input[0][2]);
 
       return (data === null)
-        ? formatReviewsResponse(savedReviews)
+        ? formatReviewsResponse({ reviews: savedReviews, token: null, num })
         : processReviewsAndGetNextPage(data, opts, savedReviews);
     });
 }


### PR DESCRIPTION
The .reviews function crashes when trying to get the reviews of this app:

https://play.google.com/store/apps/details?id=com.knifedesignideas.pondokonline7

The "formatReviewsResponse" expects a json object of three keys as input, but it receives input of different type.

This PR fixes the issue.