### PR TITLE
Add game features detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ Results:
   recentChanges: 'Improved offline translations with upgraded language downloads',
   comments: [],
   editorsChoice: true,
+  features: [
+    {
+      title: 'Uses Google Play Games',
+      description: 'For automatic sign-in, leaderboards, achievements, and more.'
+    },
+    {
+      title: 'Achievements',
+      description: 'Grants you achievements for completing goals and skill-based challenges.'
+    }
+  ],
   appId: 'com.google.android.apps.translate',
   url: 'https://play.google.com/store/apps/details?id=com.google.android.apps.translate&hl=en&gl=us'
 }

--- a/lib/mappers/clusters.js
+++ b/lib/mappers/clusters.js
@@ -30,6 +30,9 @@ const MAPPINGS = {
       }
     },
     new: {
+      1: {
+        [c.collection.NEW_FREE]: 0
+      },
       2: {
         [c.collection.NEW_FREE]: 0,
         [c.collection.NEW_PAID]: 1

--- a/lib/mappers/details.js
+++ b/lib/mappers/details.js
@@ -96,8 +96,25 @@ const MAPPINGS = {
   editorsChoice: {
     path: ['ds:5', 0, 12, 15, 0],
     fun: Boolean
+  },
+  features: {
+    path: ['ds:5', 0, 12, 16],
+    fun: extractFeatures
   }
 };
+
+function extractFeatures (featuresArray) {
+  if (featuresArray === null) {
+    return [];
+  }
+
+  const features = featuresArray[2] || [];
+
+  return features.map(feature => ({
+    title: feature[0],
+    description: R.path([1, 0, 0, 1], feature)
+  }));
+}
 
 function descriptionText (description) {
   // preserve the line breaks when converting to text
@@ -114,6 +131,7 @@ function normalizeAndroidVersion (androidVersionText) {
   if (parseFloat(number)) {
     return number;
   }
+
   return 'VARY';
 }
 
@@ -121,6 +139,7 @@ function buildHistogram (container) {
   if (!container) {
     return { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
   }
+
   return {
     1: container[1][1],
     2: container[2][1],

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -31,7 +31,7 @@ const validateAppDetails = (app) => {
   }
   assert.isString(app.contentRating);
 
-  assert.equal(app.androidVersion, '4.1');
+  assert.equal(app.androidVersion, '4.4');
 
   assert.equal(app.priceText, 'Free');
   assert.equal(app.price, 0);
@@ -59,6 +59,8 @@ const validateAppDetails = (app) => {
   assert.isString(app.recentChanges);
 
   assert.isBoolean(app.editorsChoice);
+
+  assert.equal(2, app.features.length);
 };
 
 describe('App method', () => {
@@ -67,7 +69,7 @@ describe('App method', () => {
       .then((app) => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=en&gl=us');
         assert.equal(app.genre, 'Puzzle');
-        assert.equal(app.androidVersionText, '4.1 and up');
+        assert.equal(app.androidVersionText, '4.4 and up');
         validateAppDetails(app);
       });
   });
@@ -81,7 +83,7 @@ describe('App method', () => {
       .then((app) => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=es&gl=es');
         assert.equal(app.genre, 'Puzles');
-        assert.equal(app.androidVersionText, '4.1 y versiones posteriores');
+        assert.equal(app.androidVersionText, '4.4 y versiones posteriores');
         validateAppDetails(app);
       });
   });
@@ -95,7 +97,7 @@ describe('App method', () => {
       .then((app) => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=pt&gl=br');
         assert.equal(app.genre, 'Quebra-cabeça');
-        assert.equal(app.androidVersionText, '4.1 ou superior');
+        assert.equal(app.androidVersionText, '4.4 ou superior');
         validateAppDetails(app);
       });
   });
@@ -130,8 +132,8 @@ describe('App method', () => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=es&gl=ar');
         assert.isNumber(app.minInstalls);
 
-        assert.equal(app.androidVersion, '4.1');
-        assert.equal(app.androidVersionText, '4.1 y versiones posteriores');
+        assert.equal(app.androidVersion, '4.4');
+        assert.equal(app.androidVersionText, '4.4 y versiones posteriores');
       });
   });
 
@@ -143,8 +145,8 @@ describe('App method', () => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=fr&gl=fr');
         assert.isNumber(app.minInstalls);
 
-        assert.equal(app.androidVersion, '4.1');
-        assert.equal(app.androidVersionText, '4.1 ou version ultérieure');
+        assert.equal(app.androidVersion, '4.4');
+        assert.equal(app.androidVersionText, '4.4 ou version ultérieure');
       }));
 
   it('should reject the promise for an invalid appId', () =>

--- a/test/lib.developer.js
+++ b/test/lib.developer.js
@@ -31,7 +31,11 @@ describe('Developer method', () => {
       .then((apps) => {
         apps.forEach((app) => {
           assert.isNumber(app.minInstalls);
-          assert.isNumber(app.reviews);
+          // IF APP IS NOT RELEASED
+          // THIS MEANS THAT IT SHOULDN'T HAVE REVIEWS
+          if (app.released) {
+            assert.isNumber(app.reviews);
+          }
 
           assert.isString(app.description);
           assert.isString(app.descriptionHTML);

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -98,14 +98,25 @@ describe('List method', () => {
       .then((apps) => apps.map((app) => assert(app.free)));
   }).timeout(timeout);
 
-  it('should fetch a valid application list for the new paid collection and FAMILY category', () => {
+  it('should return error for application list for the new paid collection and FAMILY category', () => {
+    const collection = gplay.collection.NEW_PAID;
+
     return gplay.list({
-      collection: gplay.collection.NEW_PAID,
+      collection,
+      category: gplay.category.FAMILY,
+      num: 100
+    })
+      .catch((error) => assert.equal(error.message, `The collection ${collection} is invalid for the given category, top apps or new apps`));
+  }).timeout(timeout);
+
+  it('should fetch apps for application list for the new free collection and FAMILY category', () => {
+    return gplay.list({
+      collection: gplay.category.NEW_FREE,
       category: gplay.category.FAMILY,
       num: 100
     })
       .then((apps) => apps.map(assertValidApp))
-      .then((apps) => apps.map((app) => assert.isFalse(app.free)));
+      .then((apps) => apps.map((app) => assert(app.free)));
   }).timeout(timeout);
 
   it('should validate the category', () => {


### PR DESCRIPTION
This PR adds new fields to full detail apps and implement the feature request:
#446 

For games, we have some integrated features displayed in Google Play Store.
We can capture those fields and make them available.
The new field looks like this:
```js
  features: [
    {
      title: 'Uses Google Play Games',
      description: 'For automatic sign-in, leaderboards, achievements, and more.'
    },
    {
      title: 'Achievements',
      description: 'Grants you achievements for completing goals and skill-based challenges.'
    },
    {
      title: 'Leaderboards',
      description: 'Compare your scores with your friends and other Play Games players.'
    },
    {
      title: 'Saved Games',
      description: 'Save your progress and pick up where you left off on any device.'
    }
  ],
```

I have also:
[9793930](https://github.com/facundoolano/google-play-scraper/pull/457/commits/9793930a3620c5c37916b724bee7d84eb044d47c): fixed `.app` tests (the rating for the test app is no 4.4 - congrats btw 🚀)
[326482d](https://github.com/facundoolano/google-play-scraper/commit/326482d167b8907875f71638ddfa3ec7b9b8b7a9): fixed `.developer` tests (an app from google is not released and therefore it have no reviews)
[b873e65](https://github.com/facundoolano/google-play-scraper/commit/b873e65806c8f01dac6530e58b93bf90d3606d94): fixed `.list` tests since google removed the categories **new** section 