### PR TITLE
Fix .similar full detail

### DIFF
--- a/lib/mappers/clusters.js
+++ b/lib/mappers/clusters.js
@@ -30,6 +30,9 @@ const MAPPINGS = {
       }
     },
     new: {
+      1: {
+        [c.collection.NEW_FREE]: 0
+      },
       2: {
         [c.collection.NEW_FREE]: 0,
         [c.collection.NEW_PAID]: 1

--- a/lib/mappers/similar.js
+++ b/lib/mappers/similar.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const INITIAL_MAPPINGS = {
+  cluster: ['ds:7', 1, 1, 0, 0, 3, 4, 2],
+  apps: ['ds:3', 0, 1, 0, 0, 0],
+  token: ['ds:3', 0, 1, 0, 0, 7, 1]
+};
+
+module.exports = {
+  INITIAL_MAPPINGS
+};

--- a/lib/parsers/parseSimilarApps.js
+++ b/lib/parsers/parseSimilarApps.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const R = require('ramda');
+const debug = require('debug')('google-play-scraper:parseSimilarApps');
+const request = require('../utils/request');
+const scriptData = require('../utils/scriptData');
+const { BASE_URL } = require('../utils/configurations');
+const { processAndRecur } = require('../requesters/appsMappedRequests');
+const { INITIAL_MAPPINGS } = require('../mappers/similar')
+
+function getParsedCluster (similarObject) {
+  const clusterUrl = R.path(INITIAL_MAPPINGS.cluster, similarObject);
+  return clusterUrl;
+}
+
+function parseSimilarApps (similarObject, opts) {
+  const clusterUrl = getParsedCluster(similarObject);
+
+  if (clusterUrl === undefined) {
+    throw Error('Similar link not found');
+  }
+
+  const fullClusterUrl = `${BASE_URL}${clusterUrl}&gl=${opts.country}&hl=${opts.lang}`;
+  debug('Cluster Request URL: %s', fullClusterUrl);
+
+  const options = Object.assign({
+    url: fullClusterUrl,
+    followAllRedirects: true
+  }, opts.requestOptions);
+
+  return request(options, opts.throttle)
+    .then(scriptData.parse)
+    .then((htmlParsed) => processAndRecur(htmlParsed, opts, [], INITIAL_MAPPINGS))
+}
+
+module.exports = parseSimilarApps;

--- a/lib/parsers/parseSimilarApps.js
+++ b/lib/parsers/parseSimilarApps.js
@@ -6,7 +6,7 @@ const request = require('../utils/request');
 const scriptData = require('../utils/scriptData');
 const { BASE_URL } = require('../utils/configurations');
 const { processAndRecur } = require('../requesters/appsMappedRequests');
-const { INITIAL_MAPPINGS } = require('../mappers/similar')
+const { INITIAL_MAPPINGS } = require('../mappers/similar');
 
 function getParsedCluster (similarObject) {
   const clusterUrl = R.path(INITIAL_MAPPINGS.cluster, similarObject);
@@ -30,7 +30,7 @@ function parseSimilarApps (similarObject, opts) {
 
   return request(options, opts.throttle)
     .then(scriptData.parse)
-    .then((htmlParsed) => processAndRecur(htmlParsed, opts, [], INITIAL_MAPPINGS))
+    .then((htmlParsed) => processAndRecur(htmlParsed, opts, [], INITIAL_MAPPINGS));
 }
 
 module.exports = parseSimilarApps;

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -1,55 +1,50 @@
 'use strict';
 
+const debug = require('debug')('google-play-scraper:similar');
 const request = require('./utils/request');
 const queryString = require('querystring');
 const scriptData = require('./utils/scriptData');
-const appList = require('./utils/appList');
-
-const PLAYSTORE_URL = 'https://play.google.com/store/apps/details';
+const { BASE_URL, DEFAULT_PARAMETERS } = require('./utils/configurations');
+const parseSimilarApps = require('./parsers/parseSimilarApps');
 
 function similar (opts) {
   return new Promise(function (resolve, reject) {
-    if (!opts || !opts.appId) {
-      throw Error('appId missing');
-    }
+    validateSimilarParameters(opts);
 
-    opts.appId = encodeURIComponent(opts.appId);
-    opts.lang = opts.lang || 'en';
-    opts.country = opts.country || 'us';
+    const mergedOpts = Object.assign({},
+      {
+        appId: encodeURIComponent(opts.appId),
+        lang: opts.lang || DEFAULT_PARAMETERS.similar.lang,
+        country: opts.country || DEFAULT_PARAMETERS.similar.country,
+        fullDetail: opts.fullDetail || DEFAULT_PARAMETERS.similar.fullDetail
+      });
 
     const qs = queryString.stringify({
-      id: opts.appId,
-      hl: opts.lang,
-      gl: opts.country
+      id: mergedOpts.appId,
+      hl: mergedOpts.lang,
+      gl: mergedOpts.country
     });
-    const reqUrl = `${PLAYSTORE_URL}?${qs}`;
 
+    const similarUrl = `${BASE_URL}/store/apps/details?${qs}`;
     const options = Object.assign({
-      url: reqUrl,
+      url: similarUrl,
       followAllRedirects: true
     }, opts.requestOptions);
 
+    debug('Similar Request URL: %s', similarUrl);
+
     request(options, opts.throttle)
       .then(scriptData.parse)
-      .then(scriptData.extractor(PATH_MAPPING))
-      .then(data => {
-        if (data.path === undefined) {
-          throw Error('not found similar link');
-        }
-        return request(Object.assign({
-          url: `https://play.google.com${data.path}&gl=${opts.country}&hl=${opts.lang}`,
-          followAllRedirects: true
-        }, opts.requestOptions));
-      })
-      .then(scriptData.parse)
-      .then((parsed) => appList.extract(['ds:3', 0, 1, 0, 0, 0], parsed))
+      .then(parsedObject => parseSimilarApps(parsedObject, mergedOpts))
       .then(resolve)
       .catch(reject);
   });
 }
 
-const PATH_MAPPING = {
-  path: ['ds:7', 1, 1, 0, 0, 3, 4, 2]
-};
+function validateSimilarParameters (opts) {
+  if (!opts || !opts.appId) {
+    throw Error('appId missing');
+  }
+}
 
 module.exports = similar;

--- a/lib/utils/configurations.js
+++ b/lib/utils/configurations.js
@@ -9,7 +9,7 @@ const DEFAULT_PARAMETERS = {
     country: 'us',
     fullDetail: false
   }
-}
+};
 
 module.exports = {
   BASE_URL,

--- a/lib/utils/configurations.js
+++ b/lib/utils/configurations.js
@@ -3,7 +3,16 @@
 const BASE_URL = 'https://play.google.com';
 const CLUSTER_BASE_URL = `${BASE_URL}/store/apps`;
 
+const DEFAULT_PARAMETERS = {
+  similar: {
+    lang: 'en',
+    country: 'us',
+    fullDetail: false
+  }
+}
+
 module.exports = {
   BASE_URL,
-  CLUSTER_BASE_URL
+  CLUSTER_BASE_URL,
+  DEFAULT_PARAMETERS
 };

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -31,7 +31,7 @@ const validateAppDetails = (app) => {
   }
   assert.isString(app.contentRating);
 
-  assert.equal(app.androidVersion, '4.1');
+  assert.equal(app.androidVersion, '4.4');
 
   assert.equal(app.priceText, 'Free');
   assert.equal(app.price, 0);
@@ -67,7 +67,7 @@ describe('App method', () => {
       .then((app) => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=en&gl=us');
         assert.equal(app.genre, 'Puzzle');
-        assert.equal(app.androidVersionText, '4.1 and up');
+        assert.equal(app.androidVersionText, '4.4 and up');
         validateAppDetails(app);
       });
   });
@@ -81,7 +81,7 @@ describe('App method', () => {
       .then((app) => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=es&gl=es');
         assert.equal(app.genre, 'Puzles');
-        assert.equal(app.androidVersionText, '4.1 y versiones posteriores');
+        assert.equal(app.androidVersionText, '4.4 y versiones posteriores');
         validateAppDetails(app);
       });
   });
@@ -95,7 +95,7 @@ describe('App method', () => {
       .then((app) => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=pt&gl=br');
         assert.equal(app.genre, 'Quebra-cabeça');
-        assert.equal(app.androidVersionText, '4.1 ou superior');
+        assert.equal(app.androidVersionText, '4.4 ou superior');
         validateAppDetails(app);
       });
   });
@@ -130,8 +130,8 @@ describe('App method', () => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=es&gl=ar');
         assert.isNumber(app.minInstalls);
 
-        assert.equal(app.androidVersion, '4.1');
-        assert.equal(app.androidVersionText, '4.1 y versiones posteriores');
+        assert.equal(app.androidVersion, '4.4');
+        assert.equal(app.androidVersionText, '4.4 y versiones posteriores');
       });
   });
 
@@ -143,8 +143,8 @@ describe('App method', () => {
         assert.equal(app.url, 'https://play.google.com/store/apps/details?id=com.sgn.pandapop.gp&hl=fr&gl=fr');
         assert.isNumber(app.minInstalls);
 
-        assert.equal(app.androidVersion, '4.1');
-        assert.equal(app.androidVersionText, '4.1 ou version ultérieure');
+        assert.equal(app.androidVersion, '4.4');
+        assert.equal(app.androidVersionText, '4.4 ou version ultérieure');
       }));
 
   it('should reject the promise for an invalid appId', () =>

--- a/test/lib.developer.js
+++ b/test/lib.developer.js
@@ -31,7 +31,11 @@ describe('Developer method', () => {
       .then((apps) => {
         apps.forEach((app) => {
           assert.isNumber(app.minInstalls);
-          assert.isNumber(app.reviews);
+          // IF APP IS NOT RELEASED
+          // THIS MEANS THAT IT SHOULDN'T HAVE REVIEWS
+          if (app.released) {
+            assert.isNumber(app.reviews);
+          }
 
           assert.isString(app.description);
           assert.isString(app.descriptionHTML);

--- a/test/lib.list.js
+++ b/test/lib.list.js
@@ -98,14 +98,25 @@ describe('List method', () => {
       .then((apps) => apps.map((app) => assert(app.free)));
   }).timeout(timeout);
 
-  it('should fetch a valid application list for the new paid collection and FAMILY category', () => {
+  it('should return error for application list for the new paid collection and FAMILY category', () => {
+    const collection = gplay.collection.NEW_PAID;
+
     return gplay.list({
-      collection: gplay.collection.NEW_PAID,
+      collection,
+      category: gplay.category.FAMILY,
+      num: 100
+    })
+      .catch((error) => assert.equal(error.message, `The collection ${collection} is invalid for the given category, top apps or new apps`));
+  }).timeout(timeout);
+
+  it('should fetch apps for application list for the new free collection and FAMILY category', () => {
+    return gplay.list({
+      collection: gplay.category.NEW_FREE,
       category: gplay.category.FAMILY,
       num: 100
     })
       .then((apps) => apps.map(assertValidApp))
-      .then((apps) => apps.map((app) => assert.isFalse(app.free)));
+      .then((apps) => apps.map((app) => assert(app.free)));
   }).timeout(timeout);
 
   it('should validate the category', () => {


### PR DESCRIPTION
This PR fixes the following issue:
#406

The `fullDetail` option was not working for the `.similar` method

I have also:
[d200895](https://github.com/facundoolano/google-play-scraper/commit/d20089557cf73a1d1d9a3bdd5334d7f98fa78a0b): fixed `.app` tests (the rating for the test app is no 4.4 - congrats btw 🚀)
[13f22e4](https://github.com/facundoolano/google-play-scraper/commit/13f22e4f140dcfbd7368e2fa0b1e77996b07e546): fixed `.developer` tests (an app from google is not released and therefore it have no reviews)
[2c9a07c](https://github.com/facundoolano/google-play-scraper/commit/2c9a07c4f578069a2c7ae026d97fc467d49536e6): fixed `.list` tests since google removed the categories **new** section 