### PR TITLE
Adding missing field `developerInternalID`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,7 @@ export interface IAppItemFullDetail extends IAppItem {
   androidVersionText: string
   developer: string
   developerId: string
+  developerInternalID: string
   developerEmail: string
   developerWebsite: string
   developerAddress: string


### PR DESCRIPTION
The field `developerInternalID` which is mentioned in the documentation, should be in the interface to `IAppItemFullDetail`