### PR TITLE
Fix missing cluster length

### DIFF
--- a/lib/mappers/clusters.js
+++ b/lib/mappers/clusters.js
@@ -37,6 +37,11 @@ const MAPPINGS = {
         [c.collection.NEW_FREE]: 0,
         [c.collection.NEW_PAID]: 1
       },
+      3: {
+        [c.collection.NEW_FREE]: 0,
+        [c.collection.NEW_PAID]: 1,
+        [c.collection.NEW_FREE_GAMES]: 2
+      },
       4: {
         [c.collection.NEW_FREE]: 0,
         [c.collection.NEW_PAID]: 1,


### PR DESCRIPTION
The "new" collection clusters were missing the 3 length, causing current shape of the store to break.

This seems to be more brittle than it should.