### PR TITLE
Also parse suggested search results

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -90,6 +90,11 @@ async function processFirstPage (html, opts, savedApps, mappings) {
     score: [0, 4, 1]
   };
 
+  const hasSuggestedSearch = R.is(String, R.path([...mappings.sections, 0, ...SECTIONS_MAPPING.noResults], html));
+  if (hasSuggestedSearch) {
+    R.path(mappings.sections, html).shift();
+  }
+
   const hasAboutTheseResults = R.is(String, R.path(SECTIONS_MAPPING.aboutResultsTitle, html));
   if (hasAboutTheseResults) {
     R.path(mappings.sections, html).shift();

--- a/lib/search.js
+++ b/lib/search.js
@@ -90,15 +90,7 @@ async function processFirstPage (html, opts, savedApps, mappings) {
     score: [0, 4, 1]
   };
 
-  const hasSuggestedSearch = R.is(String, R.path([...mappings.sections, 0, ...SECTIONS_MAPPING.noResults], html));
-  if (hasSuggestedSearch) {
-    R.path(mappings.sections, html).shift();
-  }
-
-  const hasAboutTheseResults = R.is(String, R.path(SECTIONS_MAPPING.aboutResultsTitle, html));
-  if (hasAboutTheseResults) {
-    R.path(mappings.sections, html).shift();
-  }
+  removeUnneededSections(html, mappings);
 
   const sections = R.path(mappings.sections, html);
   let moreResultsSection;
@@ -115,6 +107,7 @@ async function processFirstPage (html, opts, savedApps, mappings) {
       moreResultsSection = sections[0];
     }
   }
+
   const processedApps = R.map(scriptData.extractor(moreResultsMapping), R.path(SECTIONS_MAPPING.apps, moreResultsSection));
   if (mainApp) {
     processedApps.unshift(mainApp);
@@ -133,6 +126,29 @@ function isMoreSection (section) {
   return R.is(String, sectionTitle) && !R.isEmpty(sectionTitle);
 }
 
+/**
+ * Removes unused sections that contain no app informations
+ * Removed sections:
+ * * About these results
+ * * Suggested message
+ *
+ * Note: For EU countries the suggested message is shown before the About section
+ *       while for no result it is reverted
+ */
+function removeUnneededSections (html, mappings) {
+  removeSectionsIfPathValueOfType(html, SECTIONS_MAPPING.aboutResultsTitle, String);
+  // if the search function does no longer throw when no result was returned
+  // mapping SECTIONS_MAPPING.suggestedResultDescritpion can be replaced with SECTIONS_MAPPING.noResult mapping
+  removeSectionsIfPathValueOfType(html, [...mappings.sections, 0, ...SECTIONS_MAPPING.suggestedResultDescritpion], String);
+  removeSectionsIfPathValueOfType(html, SECTIONS_MAPPING.aboutResultsTitle, String);
+}
+
+function removeSectionsIfPathValueOfType (html, path, type) {
+  if (R.is(type, R.path(path, html))) {
+    R.path(INITIAL_MAPPINGS.sections, html).shift();
+  }
+}
+
 const INITIAL_MAPPINGS = {
   app: ['ds:4', 0, 1, 0, 23],
   sections: ['ds:4', 0, 1]
@@ -143,6 +159,7 @@ const SECTIONS_MAPPING = {
   token: [22, 1, 3, 1],
   apps: [22, 0],
   noResults: [25, 0, 0, 0, 1],
+  suggestedResultDescritpion: [25, 0, 0, 1, 1],
   aboutResultsTitle: ['ds:4', 0, 1, 0, 31, 0]
 };
 

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -95,17 +95,26 @@ describe('Search method', () => {
 
     it('should throw if no result returned', () => {
       return gplay.search({ term: 'asdasdyxcnmjysalsaflaslf' })
-        .catch((error) => assert.isNotEmpty(error.message));
+        .catch((error) => {
+          assert.isNotEmpty(error.message);
+          assert.match(error.message, /asdasdyxcnmjysalsaflaslf/);
+        });
     });
 
     it('should throw if no result returned in eu country store', () => {
       return gplay.search({ term: 'ASyyDASDyyASDASD', country: 'DE', lang: 'SP' })
-        .catch((error) => assert.isNotEmpty(error.message));
+        .catch((error) => {
+          assert.isNotEmpty(error.message);
+          assert.match(error.message, /ASyyDASDyyASDASD/);
+        });
     });
 
     it('should throw if no result returned in us store with other language', () => {
       return gplay.search({ term: 'ASyyDASDyyASDASD', country: 'US', lang: 'FR' })
-        .catch((error) => assert.isNotEmpty(error.message));
+        .catch((error) => {
+          assert.isNotEmpty(error.message);
+          assert.match(error.message, /ASyyDASDyyASDASD/);
+        });
     });
   });
 

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -97,6 +97,16 @@ describe('Search method', () => {
       return gplay.search({ term: 'asdasdyxcnmjysalsaflaslf' })
         .catch((error) => assert.isNotEmpty(error.message));
     });
+
+    it('should throw if no result returned in eu country store', () => {
+      return gplay.search({ term: 'ASyyDASDyyASDASD', country: 'DE', lang: 'SP' })
+        .catch((error) => assert.isNotEmpty(error.message));
+    });
+
+    it('should throw if no result returned in us store with other language', () => {
+      return gplay.search({ term: 'ASyyDASDyyASDASD', country: 'US', lang: 'FR' })
+        .catch((error) => assert.isNotEmpty(error.message));
+    });
   });
 
   describe('suggested search', () => {

--- a/test/lib.search.js
+++ b/test/lib.search.js
@@ -98,4 +98,22 @@ describe('Search method', () => {
         .catch((error) => assert.isNotEmpty(error.message));
     });
   });
+
+  describe('suggested search', () => {
+    it('should return apps from suggested search', () => {
+      return gplay.search({ term: 'runing app' })
+        .then((apps) => {
+          apps.map(assertValidApp);
+          assertIdsInArray(apps, 'com.runtastic.android', 'running.tracker.gps.map', 'com.google.android.apps.fitness');
+        });
+    });
+
+    it('should return apps from suggested search in european country', () => {
+      return gplay.search({ term: 'runing tracker', country: 'GR' })
+        .then((apps) => {
+          apps.map(assertValidApp);
+          assertIdsInArray(apps, 'com.runtastic.android', 'running.tracker.gps.map', 'com.google.android.apps.fitness');
+        });
+    });
+  });
 });


### PR DESCRIPTION
This PR is addressing the parsing of apps from suggested results as described in https://github.com/facundoolano/google-play-scraper/issues/566

Same approach as for the **About these results** fix.
Whenever there is a suggested search text, identified by checking if **any** string is present at a given location, the whole section is removed from the parsed html 