### PR TITLE
Fixed similar method to support games

### DIFF
--- a/lib/similar.js
+++ b/lib/similar.js
@@ -71,7 +71,7 @@ function parseSimilarApps (similarObject, opts) {
   let similarAppsCluster = clusters.filter(cluster => {
     return R.path(CLUSTER_MAPPING.title, cluster) === SIMILAR_APPS ||
            R.path(CLUSTER_MAPPING.title, cluster) === SIMILAR_GAMES ||
-           clusters
+           clusters;
   });
   
   if (similarAppsCluster.length === 0) {

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -68,12 +68,13 @@ function parseSimilarApps (similarObject, opts) {
   if (clusters.length === 0) {
     throw Error('Similar apps not found');
   }
+
   let similarAppsCluster = clusters.filter(cluster => {
     return R.path(CLUSTER_MAPPING.title, cluster) === SIMILAR_APPS ||
            R.path(CLUSTER_MAPPING.title, cluster) === SIMILAR_GAMES ||
            clusters;
   });
-  
+
   if (similarAppsCluster.length === 0) {
     similarAppsCluster = clusters;
   }

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -61,13 +61,19 @@ const CLUSTER_MAPPING = {
 };
 
 const SIMILAR_APPS = 'Similar apps';
+const SIMILAR_GAMES = 'Similar games';
 
 function parseSimilarApps (similarObject, opts) {
   const clusters = R.path(INITIAL_MAPPINGS.clusters, similarObject);
   if (clusters.length === 0) {
     throw Error('Similar apps not found');
   }
-  let similarAppsCluster = clusters.filter(cluster => R.path(CLUSTER_MAPPING.title, cluster) === SIMILAR_APPS) || clusters;
+  let similarAppsCluster = clusters.filter(cluster => {
+    return R.path(CLUSTER_MAPPING.title, cluster) === SIMILAR_APPS ||
+           R.path(CLUSTER_MAPPING.title, cluster) === SIMILAR_GAMES ||
+           clusters
+  });
+  
   if (similarAppsCluster.length === 0) {
     similarAppsCluster = clusters;
   }

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -23,7 +23,7 @@ function similar (opts) {
 
     const qs = queryString.stringify({
       id: mergedOpts.appId,
-      hl: mergedOpts.lang,
+      hl: 'en',
       gl: mergedOpts.country
     });
 

--- a/test/lib.similar.js
+++ b/test/lib.similar.js
@@ -12,6 +12,6 @@ describe('Similar method', () => {
 
   it('should fetch games from different developers', () => {
     return gplay.similar({ appId: 'com.mojang.minecraftpe' })
-      .then((apps) => assert.isTrue(apps.some(app => app.developer != apps[0].developer)));
+      .then((apps) => assert.isTrue(apps.some(app => app.developer !== apps[0].developer)));
   });
 });

--- a/test/lib.similar.js
+++ b/test/lib.similar.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('chai').assert;
 const gplay = require('../index');
 const assertValidApp = require('./common').assertValidApp;
 
@@ -7,5 +8,10 @@ describe('Similar method', () => {
   it('should fetch a valid application list', () => {
     return gplay.similar({ appId: 'com.mojang.minecraftpe' })
       .then((apps) => apps.map(assertValidApp));
+  });
+
+  it('should fetch games from different developers', () => {
+    return gplay.similar({ appId: 'com.mojang.minecraftpe' })
+      .then((apps) => assert.isTrue(apps.some(app => app.developer != apps[0].developer)));
   });
 });


### PR DESCRIPTION
Example: https://play.google.com/store/apps/details?id=co.yakand.agentaapuzzleindisguise&hl=en&gl=us only brings apps from the "More by..." section instead of the similar apps. This is because the scraper was looking for the "Similar apps" cluster and now it's called "Similar games" for games.