### PR TITLE
Fix app details mapping for asian countries

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -33,7 +33,7 @@ function app (opts) {
     request(options, opts.throttle)
       .then(scriptData.parse)
     // comment next line to get raw data
-      .then(scriptData.extractor(MAPPINGS))
+      .then(scriptData.extractor(MAPPINGS, 'Ws7gDc'))
       .then(R.assoc('appId', opts.appId))
       .then(R.assoc('url', reqUrl))
       .then(resolve)
@@ -41,102 +41,107 @@ function app (opts) {
   });
 }
 
+/**
+ * Root path for the mapping will be determined by the extract fon in scriptData#extractor
+ * scriptData#extractDataWithServiceRequestId will determine the root path with id `Ws7gDc`
+ */
 const MAPPINGS = {
-  title: ['ds:4', 1, 2, 0, 0],
+  title: [1, 2, 0, 0],
   description: {
-    path: ['ds:4', 1, 2, 72, 0, 1],
+    path: [1, 2, 72, 0, 1],
     fun: helper.descriptionText
   },
-  descriptionHTML: ['ds:4', 1, 2, 72, 0, 1],
-  summary: ['ds:4', 1, 2, 73, 0, 1],
-  installs: ['ds:4', 1, 2, 13, 0],
-  minInstalls: ['ds:4', 1, 2, 13, 1],
-  maxInstalls: ['ds:4', 1, 2, 13, 2],
-  score: ['ds:4', 1, 2, 51, 0, 1],
-  scoreText: ['ds:4', 1, 2, 51, 0, 0],
-  ratings: ['ds:4', 1, 2, 51, 2, 1],
-  reviews: ['ds:4', 1, 2, 51, 3, 1],
+  descriptionHTML: [1, 2, 72, 0, 1],
+  summary: [1, 2, 73, 0, 1],
+  installs: [1, 2, 13, 0],
+  minInstalls: [1, 2, 13, 1],
+  maxInstalls: [1, 2, 13, 2],
+  score: [1, 2, 51, 0, 1],
+  scoreText: [1, 2, 51, 0, 0],
+  ratings: [1, 2, 51, 2, 1],
+  reviews: [1, 2, 51, 3, 1],
   histogram: {
-    path: ['ds:4', 1, 2, 51, 1],
+    path: [1, 2, 51, 1],
     fun: helper.buildHistogram
   },
   price: {
-    path: ['ds:4', 1, 2, 57, 0, 0, 0, 0, 1, 0, 0],
+    path: [1, 2, 57, 0, 0, 0, 0, 1, 0, 0],
     fun: (val) => val / 1000000 || 0
   },
   free: {
-    path: ['ds:4', 1, 2, 57, 0, 0, 0, 0, 1, 0, 0],
+    path: [1, 2, 57, 0, 0, 0, 0, 1, 0, 0],
     // considered free only if price is exactly zero
     fun: (val) => val === 0
   },
-  currency: ['ds:4', 1, 2, 57, 0, 0, 0, 0, 1, 0, 1],
+  currency: [1, 2, 57, 0, 0, 0, 0, 1, 0, 1],
   priceText: {
-    path: ['ds:4', 1, 2, 57, 0, 0, 0, 0, 1, 0, 2],
+    path: [1, 2, 57, 0, 0, 0, 0, 1, 0, 2],
     fun: helper.priceText
   },
   available: {
-    path: ['ds:4', 1, 2, 18, 0],
+    path: [1, 2, 18, 0],
     fun: Boolean
   },
   offersIAP: {
-    path: ['ds:4', 1, 2, 19, 0],
+    path: [1, 2, 19, 0],
     fun: Boolean
   },
-  IAPRange: ['ds:4', 1, 2, 19, 0],
+  IAPRange: [1, 2, 19, 0],
   androidVersion: {
-    path: ['ds:4', 1, 2, 140, 1, 1, 0, 0, 1],
+    path: [1, 2, 140, 1, 1, 0, 0, 1],
     fun: helper.normalizeAndroidVersion
   },
   androidVersionText: {
-    path: ['ds:4', 1, 2, 140, 1, 1, 0, 0, 1],
+    path: [1, 2, 140, 1, 1, 0, 0, 1],
     fun: (version) => version || 'Varies with device'
   },
-  developer: ['ds:4', 1, 2, 68, 0],
+  developer: [1, 2, 68, 0],
   developerId: {
-    path: ['ds:4', 1, 2, 68, 1, 4, 2],
+    path: [1, 2, 68, 1, 4, 2],
     fun: (devUrl) => devUrl.split('id=')[1]
   },
-  developerEmail: ['ds:4', 1, 2, 69, 1, 0],
-  developerWebsite: ['ds:4', 1, 2, 69, 0, 5, 2],
-  developerAddress: ['ds:4', 1, 2, 69, 2, 0],
-  privacyPolicy: ['ds:4', 1, 2, 99, 0, 5, 2],
+  developerEmail: [1, 2, 69, 1, 0],
+  developerWebsite: [1, 2, 69, 0, 5, 2],
+  developerAddress: [1, 2, 69, 2, 0],
+  privacyPolicy: [1, 2, 99, 0, 5, 2],
   developerInternalID: {
-    path: ['ds:4', 1, 2, 68, 1, 4, 2],
+    path: [1, 2, 68, 1, 4, 2],
     fun: (devUrl) => devUrl.split('id=')[1]
   },
-  genre: ['ds:4', 1, 2, 79, 0, 0, 0],
-  genreId: ['ds:4', 1, 2, 79, 0, 0, 2],
+  genre: [1, 2, 79, 0, 0, 0],
+  genreId: [1, 2, 79, 0, 0, 2],
   familyGenre: ['ds:5', 0, 12, 13, 1, 0],
   familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
-  icon: ['ds:4', 1, 2, 95, 0, 3, 2],
-  headerImage: ['ds:4', 1, 2, 96, 0, 3, 2],
+  icon: [1, 2, 95, 0, 3, 2],
+  headerImage: [1, 2, 96, 0, 3, 2],
   screenshots: {
-    path: ['ds:4', 1, 2, 78, 0],
+    path: [1, 2, 78, 0],
     fun: (screenshots) => {
       if (screenshots === null) return [];
       return screenshots.map(R.path([3, 2]));
     }
   },
-  video: ['ds:4', 1, 2, 100, 0, 0, 3, 2],
-  videoImage: ['ds:4', 1, 2, 100, 1, 0, 3, 2],
-  contentRating: ['ds:4', 1, 2, 9, 0],
-  contentRatingDescription: ['ds:4', 1, 2, 9, 2, 1],
+  video: [1, 2, 100, 0, 0, 3, 2],
+  videoImage: [1, 2, 100, 1, 0, 3, 2],
+  contentRating: [1, 2, 9, 0],
+  contentRatingDescription: [1, 2, 9, 2, 1],
   adSupported: {
-    path: ['ds:4', 1, 2, 48],
+    path: [1, 2, 48],
     fun: Boolean
   },
-  released: ['ds:4', 1, 2, 10, 0],
+  released: [1, 2, 10, 0],
   updated: {
-    path: ['ds:4', 1, 2, 145, 0, 1, 0],
+    path: [1, 2, 145, 0, 1, 0],
     fun: (ts) => ts * 1000
   },
   version: {
-    path: ['ds:4', 1, 2, 140, 0, 0, 0],
+    path: [1, 2, 140, 0, 0, 0],
     fun: (val) => val || 'VARY'
   },
-  recentChanges: ['ds:4', 1, 2, 144, 1, 1],
+  recentChanges: [1, 2, 144, 1, 1],
   comments: {
-    path: ['ds:8', 0],
+    useServiceRequestId: 'oCPfdb',
+    path: [0],
     isArray: true,
     fun: helper.extractComments
   }

--- a/lib/utils/mappingHelpers.js
+++ b/lib/utils/mappingHelpers.js
@@ -58,11 +58,16 @@ function extractFeatures (featuresArray) {
   }));
 }
 
+function getPathOfSpec (spec) {
+  return R.is(Array, spec) ? spec : spec.path;
+}
+
 module.exports = {
   descriptionText,
   priceText,
   normalizeAndroidVersion,
   buildHistogram,
   extractComments,
-  extractFeatures
+  extractFeatures,
+  getPathOfSpec
 };

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -2,25 +2,27 @@
 
 const debug = require('debug')('google-play-scraper:scriptData');
 const R = require('ramda');
-
+const helper = require('./mappingHelpers');
 /**
 * This method looks for the mapping inside the serviceRequestData object
 * The serviceRequestData object is mapped from the AF_dataServiceRequests html var
 *
 * @param {object} parsedData The response mapped object
 * @param {object} spec The mappings spec
+* @param {string} serviceRequestId optional id to retrieve key node from service request data
+                  This id will be ignored if the spec itself has an id defined
 */
-function extractDataWithServiceRequestId (parsedData, spec) {
+function extractDataWithServiceRequestId (parsedData, spec, serviceRequestId) {
   const serviceRequestMapping = Object.keys(parsedData.serviceRequestData);
   const filteredDsRootPath = serviceRequestMapping.filter(serviceRequest => {
     const dsValues = parsedData.serviceRequestData[serviceRequest];
 
-    return dsValues.id === spec.useServiceRequestId;
+    return dsValues.id === (spec.useServiceRequestId || serviceRequestId);
   });
 
   const formattedPath = (filteredDsRootPath.length)
-    ? [filteredDsRootPath[0], ...spec.path]
-    : spec.path;
+    ? [filteredDsRootPath[0], ...helper.getPathOfSpec(spec)]
+    : helper.getPathOfSpec(spec);
 
   return R.path(formattedPath, parsedData);
 }
@@ -32,24 +34,21 @@ function extractDataWithServiceRequestId (parsedData, spec) {
 * it to the function in object.fun
 *
 * @param {array} mappings The mappings object
+* @param {string} serviceRequestId optional id for whole extraction used to identify the node with given id
 */
-function extractor (mappings) {
+function extractor (mappings, serviceRequestId) {
   return function extractFields (parsedData) {
     debug('parsedData: %o', parsedData);
 
     return R.map((spec) => {
-      if (R.is(Array, spec)) {
-        return R.path(spec, parsedData);
-      }
-
       // extractDataWithServiceRequestId explanation:
       // https://github.com/facundoolano/google-play-scraper/pull/412
       // assume spec object
-      const input = (spec.useServiceRequestId)
-        ? extractDataWithServiceRequestId(parsedData, spec)
-        : R.path(spec.path, parsedData);
+      const input = (spec.useServiceRequestId || serviceRequestId)
+        ? extractDataWithServiceRequestId(parsedData, spec, serviceRequestId)
+        : R.path(helper.getPathOfSpec(spec), parsedData);
 
-      return spec.fun(input, parsedData);
+      return R.is(Function, spec.fun) ? spec.fun(input, parsedData) : input;
     }, mappings);
   };
 }


### PR DESCRIPTION
This PR fixes mapping of app details with the help of the service request id

DRAFT because tests are missing and   
mapping for
```
familyGenre: ['ds:5', 0, 12, 13, 1, 0],
familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
```