### PR TITLE
Add method for scraping data safety information of an app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Available methods:
 - [reviews](#reviews): Retrieves a page of reviews for a specific application.
 - [similar](#similar): Returns a list of similar apps to the one specified.
 - [permissions](#permissions): Returns the list of permissions an app has access to.
+- [datasafety](#datasafety): Returns the data safety information of an app.
 - [categories](#categories): Retrieve a full list of categories present from dropdown menu on Google Play.
 
 ### app
@@ -440,6 +441,112 @@ Results:
     type: 'Photos/Media/Files' },
   { permission: 'view network connections',
     type: '' } ]
+```
+
+### datasafety
+Returns the data safety information of an application. The data safety is categorized into lists of "data shared",
+"data collected" and "security practices". Addtionally, the URL to the privacy policy is returned.
+
+* `appId`: the Google Play id of the application to get permissions for.
+* `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the permissions.
+
+Example:
+
+```javascript
+var gplay = require('google-play-scraper');
+
+gplay.datasafety({appId: "com.dxco.pandavszombies"}).then(console.log);
+```
+
+Results:
+```javascript
+{ dataShared: [
+    {
+      data: 'User IDs',
+      optional: false,
+      purpose: 'Advertising or marketing, Account management',
+      type: 'Personal info'
+    },
+    {
+      data: 'Crash logs',
+      optional: false,
+      purpose: 'Analytics',
+      type: 'App info and performance'
+    }
+  ],
+  dataCollected: [
+    {
+      data: 'Name',
+      optional: true,
+      purpose: 'App functionality, Developer communications, Advertising or marketing',
+      type: 'Personal info'
+    },
+    {
+      data: 'Email address',
+      optional: true,
+      purpose: 'App functionality, Advertising or marketing, Account management',
+      type: 'Personal info'
+    },
+    {
+      data: 'User IDs',
+      optional: false,
+      purpose: 'App functionality, Analytics, Developer communications, Advertising or marketing, Fraud prevention, security, and compliance, Personalization, Account management',
+      type: 'Personal info'
+    },
+    {
+      data: 'Purchase history',
+      optional: true,
+      purpose: 'Account management',
+      type: 'Financial info'
+    },
+    {
+      data: 'Other in-app messages',
+      optional: false,
+      purpose: 'Developer communications, Fraud prevention, security, and compliance',
+      type: 'Messages'
+    },
+    {
+      data: 'Contacts',
+      optional: true,
+      purpose: 'App functionality',
+      type: 'Contacts'
+    },
+    {
+      data: 'Other actions',
+      optional: false,
+      purpose: 'App functionality, Analytics, Fraud prevention, security, and compliance',
+      type: 'App activity'
+    },
+    {
+      data: 'Crash logs',
+      optional: true,
+      purpose: 'App functionality, Analytics',
+      type: 'App info and performance'
+    },
+    {
+      data: 'Other app performance data',
+      optional: false,
+      purpose: 'Analytics',
+      type: 'App info and performance'
+    },
+    {
+      data: 'Device or other IDs',
+      optional: false,
+      purpose: 'App functionality, Analytics, Advertising or marketing, Fraud prevention, security, and compliance, Personalization, Account management',
+      type: 'Device or other IDs'
+    }
+  ],
+  securityPractices: [
+    {
+      practice: 'Data isn’t encrypted',
+      description: 'Your data isn’t transferred over a secure connection'
+    },
+    {
+      practice: 'You can request that data be deleted',
+      description: 'The developer provides a way for you to request that your data be deleted'
+    }
+  ],
+  privacyPolicyUrl: 'http://www.jamcity.com/privacy' }
 ```
 
 ### categories

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const methods = {
   reviews: require('./lib/reviews'),
   similar: require('./lib/similar'),
   permissions: require('./lib/permissions'),
+  datasafety: require('./lib/datasafety'),
   categories: require('./lib/categories')
 };
 
@@ -38,6 +39,7 @@ function memoized (opts) {
     reviews: require('./lib/reviews'),
     similar: require('./lib/similar'),
     permissions: require('./lib/permissions'),
+    datasafety: require('./lib/datasafety'),
     categories: require('./lib/categories')
   };
 

--- a/lib/datasafety.js
+++ b/lib/datasafety.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const R = require('ramda');
+const request = require('./utils/request');
+const scriptData = require('./utils/scriptData');
+const { BASE_URL } = require('./constants');
+
+function dataSafety (opts) {
+  return new Promise(function (resolve, reject) {
+    if (!opts && !opts.appId) {
+      throw Error('appId missing');
+    }
+
+    opts.lang = opts.lang || 'en';
+
+    processDataSafety(opts)
+      .then(resolve)
+      .catch(reject);
+  });
+}
+
+function processDataSafety (opts) {
+  const PLAYSTORE_URL = `${BASE_URL}/store/apps/datasafety`;
+
+  const searchParams = new URLSearchParams({
+    id: opts.appId,
+    hl: opts.lang
+  });
+  const reqUrl = `${PLAYSTORE_URL}?${searchParams}`;
+
+  const options = Object.assign({
+    url: reqUrl,
+    followRedirect: true
+  }, opts.requestOptions);
+
+  return request(options, opts.throttle)
+    .then(scriptData.parse)
+    .then(scriptData.extractor(MAPPINGS));
+}
+
+const MAPPINGS = {
+  sharedData: {
+    path: ['ds:3', 1, 2, 137, 4, 0, 0],
+    fun: mapDataEntries
+  },
+  collectedData: {
+    path: ['ds:3', 1, 2, 137, 4, 1, 0],
+    fun: mapDataEntries
+  },
+  securityPractices: {
+    path: ['ds:3', 1, 2, 137, 9, 2],
+    fun: mapSecurityPractices
+  },
+  privacyPolicyUrl: ['ds:3', 1, 2, 99, 0, 5, 2]
+};
+
+function mapSecurityPractices (practices) {
+  if (!practices) {
+    return [];
+  }
+
+  return practices.map((practice) => ({
+    'practice': R.path([1], practice),
+    'description': R.path([2, 1], practice)
+  }));
+}
+
+function mapDataEntries (dataEntries) {
+  if (!dataEntries) {
+    return [];
+  }
+
+  return dataEntries.flatMap(data => {
+    const type = R.path([0, 1], data);
+    const details = R.path([4], data);
+
+    return details.map(detail => ({
+      'data': R.path([0], detail),
+      'optional': R.path([1], detail),
+      'purpose': R.path([2], detail),
+      'type': type
+    }));
+  });
+}
+
+module.exports = dataSafety;

--- a/test/lib.datasafety.js
+++ b/test/lib.datasafety.js
@@ -42,7 +42,6 @@ describe('Data Safety method', () => {
   it('should return empty return for non existing app', () =>
     gplay.datasafety({ appId: 'app.foo.bar' })
       .then((dataSafety) => {
-        console.log(dataSafety);
         assert.isEmpty(dataSafety.sharedData);
         assert.isEmpty(dataSafety.collectedData);
         assert.isEmpty(dataSafety.securityPractices);

--- a/test/lib.datasafety.js
+++ b/test/lib.datasafety.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const gplay = require('../index');
+const assert = require('chai').assert;
+const assertValidUrl = require('./common').assertValidUrl;
+
+function assertValidDataSafetyObject () {
+  return (entry) => {
+    assert.isString(entry.data);
+    assert.isString(entry.purpose);
+    assert.isString(entry.type);
+    assert.isBoolean(entry.optional);
+  };
+}
+
+describe('Data Safety method', () => {
+  it('should return arrays of data shared, data collected, security practices and a privacy url', () =>
+    gplay.datasafety({ appId: 'com.sgn.pandapop.gp' })
+      .then((dataSafety) => {
+        assert.isArray(dataSafety.sharedData);
+        assert.isArray(dataSafety.collectedData);
+        assert.isArray(dataSafety.securityPractices);
+        assertValidUrl(dataSafety.privacyPolicyUrl);
+      }));
+
+  it('should return a valid shared and collected data object', () =>
+    gplay.datasafety({ appId: 'com.sgn.pandapop.gp' })
+      .then((dataSafety) => {
+        dataSafety.sharedData.map(assertValidDataSafetyObject());
+        dataSafety.collectedData.map(assertValidDataSafetyObject());
+      }));
+
+  it('should return a valid security practices object', () =>
+    gplay.datasafety({ appId: 'com.sgn.pandapop.gp' })
+      .then((dataSafety) => {
+        dataSafety.securityPractices.map((practice) => {
+          assert.isString(practice.practice);
+          assert.isString(practice.description);
+        });
+      }));
+
+  it('should return empty return for non existing app', () =>
+    gplay.datasafety({ appId: 'app.foo.bar' })
+      .then((dataSafety) => {
+        console.log(dataSafety);
+        assert.isEmpty(dataSafety.sharedData);
+        assert.isEmpty(dataSafety.collectedData);
+        assert.isEmpty(dataSafety.securityPractices);
+        assert.isUndefined(dataSafety.privacyPolicyUrl);
+      })
+  );
+});


### PR DESCRIPTION
The Play Store provides a new data safety page for each app. Developers can descripe how user data is collected, shared and what privacy practices are applied. (As mentioned in #552)

This pull reuqest adds a new method to retrieve these data safety information. An example is in the README.md.

Please feel free to change the code, or let me know what is missing. This is my first contribution. 👼 