### PR TITLE
Add genres / categories list to App details result

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,6 @@ Results:
   developerInternalID: '5700313618786177705',
   genre: 'Tools',
   genreId: 'TOOLS',
-  familyGenre: undefined,
-  familyGenreId: undefined,
   categories: [
     { name: 'Tools', id: 'TOOLS' },
     { name: 'Another category without id', id: null }

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Results:
   genreId: 'TOOLS',
   familyGenre: undefined,
   familyGenreId: undefined,
+  categories: [
+    { name: 'Tools', id: 'TOOLS' },
+    { name: 'Another category without id', id: null }
+  ],
   icon: 'https://lh3.googleusercontent.com/ZrNeuKthBirZN7rrXPN1JmUbaG8ICy3kZSHt-WgSnREsJzo2txzCzjIoChlevMIQEA',
   headerImage: 'https://lh3.googleusercontent.com/e4Sfy0cOmqpike76V6N6n-tDVbtbmt6MxbnbkKBZ_7hPHZRfsCeZhMBZK8eFDoDa1Vf-',
   screenshots: [

--- a/index.d.ts
+++ b/index.d.ts
@@ -129,8 +129,10 @@ export interface IAppItemFullDetail extends IAppItem {
   developerAddress: string
   genre: string
   genreId: string
-  familyGenre: string
-  familyGenreId: string
+  categories: Array<{
+    name: string
+    id: string|null
+  }>
   icon: string
   headerImage: string
   screenshots: string[]

--- a/lib/app.js
+++ b/lib/app.js
@@ -106,8 +106,6 @@ const MAPPINGS = {
   },
   genre: ['ds:5', 1, 2, 79, 0, 0, 0],
   genreId: ['ds:5', 1, 2, 79, 0, 0, 2],
-  familyGenre: ['ds:5', 0, 12, 13, 1, 0],
-  familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
   categories: {
     path: ['ds:5', 1, 2],
     fun: (searchArray) => {

--- a/lib/app.js
+++ b/lib/app.js
@@ -108,6 +108,10 @@ const MAPPINGS = {
   genreId: ['ds:5', 1, 2, 79, 0, 0, 2],
   familyGenre: ['ds:5', 0, 12, 13, 1, 0],
   familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
+  categories: {
+    path: ['ds:5'],
+    fun: helper.extractCategories
+  },
   icon: ['ds:5', 1, 2, 95, 0, 3, 2],
   headerImage: ['ds:5', 1, 2, 96, 0, 3, 2],
   screenshots: {

--- a/lib/app.js
+++ b/lib/app.js
@@ -109,8 +109,18 @@ const MAPPINGS = {
   familyGenre: ['ds:5', 0, 12, 13, 1, 0],
   familyGenreId: ['ds:5', 0, 12, 13, 1, 2],
   categories: {
-    path: ['ds:5'],
-    fun: helper.extractCategories
+    path: ['ds:5', 1, 2],
+    fun: (searchArray) => {
+      const categories = helper.extractCategories(R.path([118], searchArray));
+      if (categories.length === 0) {
+        // add genre and genreId like GP does when there're no categories available
+        categories.push({
+          name: R.path([79, 0, 0, 0], searchArray),
+          id: R.path([79, 0, 0, 2], searchArray)
+        });
+      }
+      return categories;
+    }
   },
   icon: ['ds:5', 1, 2, 95, 0, 3, 2],
   headerImage: ['ds:5', 1, 2, 96, 0, 3, 2],

--- a/lib/utils/mappingHelpers.js
+++ b/lib/utils/mappingHelpers.js
@@ -58,46 +58,27 @@ function extractFeatures (featuresArray) {
   }));
 }
 
-function getCategoriesRecursively (searchArray, res) {
-  if (!searchArray || !searchArray.hasOwnProperty(0)) return;
+/**
+ * Recursively extracts the categories of the App
+ * @param {array} categories The categories array
+ */
+function extractCategories (searchArray, categories = []) {
+  if (!searchArray || !searchArray.hasOwnProperty(0)) return categories;
 
   if (typeof searchArray[0] === 'string' && typeof searchArray[2] !== 'undefined') {
-    if (res.findIndex((v) => v.name === searchArray[0]) === -1) {
-      res.push({
+    if (categories.findIndex((v) => v.name === searchArray[0]) === -1) {
+      categories.push({
         name: searchArray[0],
         id: searchArray[2]
       });
     }
   } else {
     searchArray.forEach((sub) => {
-      getCategoriesRecursively(sub, res);
-    });
-  }
-}
-
-function extractCategories (searchArray) {
-  if (!searchArray) return [];
-
-  const res = [];
-
-  const genre = R.path([1, 2, 79, 0, 0, 0], searchArray);
-  if (genre) {
-    res.push({
-      name: genre,
-      id: R.path([1, 2, 79, 0, 0, 2], searchArray)
-    });
-  }
-  const familyGenre = R.path([0, 12, 13, 1, 0], searchArray);
-  if (familyGenre) {
-    res.push({
-      name: familyGenre,
-      id: R.path([0, 12, 13, 1, 2], searchArray)
+      extractCategories(sub, categories);
     });
   }
 
-  getCategoriesRecursively(R.path([1, 2, 118], searchArray), res);
-
-  return res;
+  return categories;
 }
 
 module.exports = {

--- a/lib/utils/mappingHelpers.js
+++ b/lib/utils/mappingHelpers.js
@@ -63,9 +63,9 @@ function extractFeatures (featuresArray) {
  * @param {array} categories The categories array
  */
 function extractCategories (searchArray, categories = []) {
-  if (!searchArray || !searchArray.hasOwnProperty(0)) return categories;
+  if (searchArray === null || searchArray.length === 0) return categories;
 
-  if (searchArray.length >= 2 && typeof searchArray[0] === 'string') {
+  if (searchArray.length >= 4 && typeof searchArray[0] === 'string') {
     categories.push({
       name: searchArray[0],
       id: searchArray[2]

--- a/lib/utils/mappingHelpers.js
+++ b/lib/utils/mappingHelpers.js
@@ -65,13 +65,11 @@ function extractFeatures (featuresArray) {
 function extractCategories (searchArray, categories = []) {
   if (!searchArray || !searchArray.hasOwnProperty(0)) return categories;
 
-  if (typeof searchArray[0] === 'string' && typeof searchArray[2] !== 'undefined') {
-    if (categories.findIndex((v) => v.name === searchArray[0]) === -1) {
-      categories.push({
-        name: searchArray[0],
-        id: searchArray[2]
-      });
-    }
+  if (searchArray.length >= 2 && typeof searchArray[0] === 'string') {
+    categories.push({
+      name: searchArray[0],
+      id: searchArray[2]
+    });
   } else {
     searchArray.forEach((sub) => {
       extractCategories(sub, categories);

--- a/lib/utils/mappingHelpers.js
+++ b/lib/utils/mappingHelpers.js
@@ -58,11 +58,54 @@ function extractFeatures (featuresArray) {
   }));
 }
 
+function getCategoriesRecursively (searchArray, res) {
+  if (!searchArray || !searchArray.hasOwnProperty(0)) return;
+
+  if (typeof searchArray[0] === 'string' && typeof searchArray[2] !== 'undefined') {
+    if (res.findIndex((v) => v.name === searchArray[0]) === -1) {
+      res.push({
+        name: searchArray[0],
+        id: searchArray[2]
+      });
+    }
+  } else {
+    searchArray.forEach((sub) => {
+      getCategoriesRecursively(sub, res);
+    });
+  }
+}
+
+function extractCategories (searchArray) {
+  if (!searchArray) return [];
+
+  const res = [];
+
+  const genre = R.path([1, 2, 79, 0, 0, 0], searchArray);
+  if (genre) {
+    res.push({
+      name: genre,
+      id: R.path([1, 2, 79, 0, 0, 2], searchArray)
+    });
+  }
+  const familyGenre = R.path([0, 12, 13, 1, 0], searchArray);
+  if (familyGenre) {
+    res.push({
+      name: familyGenre,
+      id: R.path([0, 12, 13, 1, 2], searchArray)
+    });
+  }
+
+  getCategoriesRecursively(R.path([1, 2, 118], searchArray), res);
+
+  return res;
+}
+
 module.exports = {
   descriptionText,
   priceText,
   normalizeAndroidVersion,
   buildHistogram,
   extractComments,
-  extractFeatures
+  extractFeatures,
+  extractCategories
 };

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -24,6 +24,12 @@ const validateAppDetails = (app) => {
   assert.equal(app.familyGenre, undefined);
   assert.equal(app.familyGenreId, undefined);
 
+  assert.isArray(app.categories);
+  assert.isAbove(app.categories.length, 1);
+  assert.equal(app.categories[0].id, 'GAME_PUZZLE');
+  assert.notEqual(app.categories[1].id, 'GAME_PUZZLE');
+  assert.hasAllKeys(app.categories[0], ['name', 'id']);
+
   assert.isString(app.version);
   if (app.size) {
     assert.isString(app.size);

--- a/test/lib.app.js
+++ b/test/lib.app.js
@@ -21,8 +21,6 @@ const validateAppDetails = (app) => {
   assert.isString(app.descriptionHTML);
   assert.isString(app.released);
   assert.equal(app.genreId, 'GAME_PUZZLE');
-  assert.equal(app.familyGenre, undefined);
-  assert.equal(app.familyGenreId, undefined);
 
   assert.isArray(app.categories);
   assert.isAbove(app.categories.length, 1);


### PR DESCRIPTION
I've noticed that there're no categories in the result of `gplay.app` as described here #554, so I've tried to add them. 
In the new `categories` array property, the `genre` and `familyGenre` name+id pairs will be present, too. Even though I've never caught familyGenre yet. They will go before any other. Duplications are prevented by the `name`.
I've decided to not set `id` if not present, if it's _null_ this means that GP does not have it as a separate category either. 