### PR TITLE
Fix: app() function specifies the lang parameter, but the description…

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -44,10 +44,10 @@ function app (opts) {
 const MAPPINGS = {
   title: ['ds:5', 1, 2, 0, 0],
   description: {
-    path: ['ds:5', 1, 2, 72, 0, 1],
+    path: ['ds:5', 1, 2, 12, 0, 0, 1],
     fun: helper.descriptionText
   },
-  descriptionHTML: ['ds:5', 1, 2, 72, 0, 1],
+  descriptionHTML: ['ds:5', 1, 2, 12, 0, 0, 1],
   summary: ['ds:5', 1, 2, 73, 0, 1],
   installs: ['ds:5', 1, 2, 13, 0],
   minInstalls: ['ds:5', 1, 2, 13, 1],


### PR DESCRIPTION
… does not take effect

for example

app: com.baidu.searchbox
lang: en
url: [https://play.google.com/store/apps/details?id=com.baidu.searchbox&hl=en&gl=us](https://play.google.com/store/apps/details?id=com.baidu.searchbox&hl=en&gl=us)
result: cn desc