### PR TITLE
fix: app description mapping always localized;

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -44,10 +44,13 @@ function app (opts) {
 const MAPPINGS = {
   title: ['ds:5', 1, 2, 0, 0],
   description: {
-    path: ['ds:5', 1, 2, 72, 0, 1],
-    fun: helper.descriptionText
+    path: ['ds:5', 1, 2],
+    fun: (val) => helper.descriptionText(helper.descriptionHtmlLocalized(val))
   },
-  descriptionHTML: ['ds:5', 1, 2, 72, 0, 1],
+  descriptionHTML: {
+    path: ['ds:5', 1, 2],
+    fun: helper.descriptionHtmlLocalized
+  },
   summary: ['ds:5', 1, 2, 73, 0, 1],
   installs: ['ds:5', 1, 2, 13, 0],
   minInstalls: ['ds:5', 1, 2, 13, 1],

--- a/lib/utils/mappingHelpers.js
+++ b/lib/utils/mappingHelpers.js
@@ -1,6 +1,13 @@
 const cheerio = require('cheerio');
 const R = require('ramda');
 
+function descriptionHtmlLocalized (searchArray) {
+  const descriptionTranslation = R.path([12, 0, 0, 1], searchArray);
+  const descriptionOriginal = R.path([72, 0, 1], searchArray);
+
+  return descriptionTranslation || descriptionOriginal;
+}
+
 function descriptionText (description) {
   // preserve the line breaks when converting to text
   const html = cheerio.load('<div>' + description.replace(/<br>/g, '\r\n') + '</div>');
@@ -59,6 +66,7 @@ function extractFeatures (featuresArray) {
 }
 
 module.exports = {
+  descriptionHtmlLocalized,
   descriptionText,
   priceText,
   normalizeAndroidVersion,


### PR DESCRIPTION
This is basically the copy of #623 PR but with some adjustments so it fallbacks to the original description, when there's no google-translated one. 

The problem in examples:
```js
gplay.app({appId: 'ua.krou.maze', lang: 'uk', country: 'UA'})
  .then(console.log, console.log);
```
has returned `description` and `descriptionHTML` in English, even though GP has its translated verstion there -- https://play.google.com/store/apps/details?id=ua.krou.maze&hl=uk&gl=UA 

Solution: check for the translated version with a fallback to the original one -- always in the requested language.