### PR TITLE
feat: allow remove hl gl if -1 in them

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -20,8 +20,8 @@ function app (opts) {
 
     const qs = queryString.stringify({
       id: opts.appId,
-      ...(opts.lang === -1 ? {} : {hl: opts.lang}),
-      ...(opts.country === -1 ? {} : {gl: opts.country}),
+      ...(opts.lang === -1 ? {} : { hl: opts.lang }),
+      ...(opts.country === -1 ? {} : { gl: opts.country })
     });
     const reqUrl = `${PLAYSTORE_URL}?${qs}`;
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -20,8 +20,8 @@ function app (opts) {
 
     const qs = queryString.stringify({
       id: opts.appId,
-      hl: opts.lang,
-      gl: opts.country
+      ...(opts.lang === -1 ? {} : {hl: opts.lang}),
+      ...(opts.country === -1 ? {} : {gl: opts.country}),
     });
     const reqUrl = `${PLAYSTORE_URL}?${qs}`;
 

--- a/lib/datasafety.js
+++ b/lib/datasafety.js
@@ -24,8 +24,8 @@ function processDataSafety (opts) {
 
   const searchParams = new URLSearchParams({
     id: opts.appId,
-    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
-    ...(opts.country === -1 ? {} : {gl: opts.country}),
+    ...(opts.lang === -1 ? {} : { hl: opts.lang }),
+    ...(opts.country === -1 ? {} : { gl: opts.country })
   });
   const reqUrl = `${PLAYSTORE_URL}?${searchParams}`;
 

--- a/lib/datasafety.js
+++ b/lib/datasafety.js
@@ -24,7 +24,8 @@ function processDataSafety (opts) {
 
   const searchParams = new URLSearchParams({
     id: opts.appId,
-    hl: opts.lang
+    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
+    ...(opts.country === -1 ? {} : {gl: opts.country}),
   });
   const reqUrl = `${PLAYSTORE_URL}?${searchParams}`;
 

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -18,8 +18,8 @@ function buildUrl (opts) {
 
   const queryString = {
     id: devId,
-    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
-    ...(opts.country === -1 ? {} : {gl: opts.country}),
+    ...(opts.lang === -1 ? {} : { hl: opts.lang }),
+    ...(opts.country === -1 ? {} : { gl: opts.country })
   };
 
   const fullURL = `${url}${path}?${qs.stringify(queryString)}`;

--- a/lib/developer.js
+++ b/lib/developer.js
@@ -10,7 +10,7 @@ const R = require('ramda');
 const { checkFinished, processFullDetailApps } = require('./utils/processPages');
 
 function buildUrl (opts) {
-  const { lang, devId, country } = opts;
+  const { devId } = opts;
   const url = `${BASE_URL}/store/apps`;
   const path = isNaN(opts.devId)
     ? `/developer`
@@ -18,8 +18,8 @@ function buildUrl (opts) {
 
   const queryString = {
     id: devId,
-    hl: lang,
-    gl: country
+    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
+    ...(opts.country === -1 ? {} : {gl: opts.country}),
   };
 
   const fullURL = `${url}${path}?${qs.stringify(queryString)}`;

--- a/lib/list.js
+++ b/lib/list.js
@@ -72,8 +72,8 @@ function validate (opts) {
 
 function buildInitialUrl (opts) {
   const queryString = {
-    hl: opts.lang,
-    gl: opts.country
+    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
+    ...(opts.country === -1 ? {} : {gl: opts.country}),
   };
 
   if (opts.age) {

--- a/lib/list.js
+++ b/lib/list.js
@@ -72,8 +72,8 @@ function validate (opts) {
 
 function buildInitialUrl (opts) {
   const queryString = {
-    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
-    ...(opts.country === -1 ? {} : {gl: opts.country}),
+    ...(opts.lang === -1 ? {} : { hl: opts.lang }),
+    ...(opts.country === -1 ? {} : { gl: opts.country })
   };
 
   if (opts.age) {

--- a/lib/search.js
+++ b/lib/search.js
@@ -29,8 +29,8 @@ function initialRequest (opts) {
   const qs = queryString.stringify({
     c: 'apps',
     q: opts.term,
-    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
-    ...(opts.country === -1 ? {} : {gl: opts.country}),
+    ...(opts.lang === -1 ? {} : { hl: opts.lang }),
+    ...(opts.country === -1 ? {} : { gl: opts.country }),
     price: opts.price
   });
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -3,6 +3,7 @@
 const R = require('ramda');
 const url = require('url');
 const request = require('./utils/request');
+const queryString = require('querystring');
 const { BASE_URL } = require('./constants');
 const { processFullDetailApps, checkFinished } = require('./utils/processPages');
 const scriptData = require('./utils/scriptData');
@@ -25,7 +26,15 @@ function initialRequest (opts) {
     return html;
   }
 
-  const url = `${BASE_URL}/store/search?c=apps&q=${opts.term}&hl=${opts.lang}&gl=${opts.country}&price=${opts.price}`;
+  const qs = queryString.stringify({
+    c: 'apps',
+    q: opts.term,
+    ...(opts.lang === -1 ? {} : {hl: opts.lang}),
+    ...(opts.country === -1 ? {} : {gl: opts.country}),
+    price: opts.price
+  });
+
+  const url = `${BASE_URL}/store/search?${qs}`;
   return request(Object.assign({ url }, opts.requestOptions), opts.throttle)
     .then(skipClusterPage)
     .then((html) => processFirstPage(html, opts, [], INITIAL_MAPPINGS));

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -23,8 +23,8 @@ function similar (opts) {
 
     const qs = queryString.stringify({
       id: mergedOpts.appId,
-      hl: 'en',
-      gl: mergedOpts.country
+      ...(mergedOpts.lang === -1 ? {} : {hl: mergedOpts.lang}),
+      ...(opts.country === -1 ? {} : {gl: mergedOpts.country}),
     });
 
     const similarUrl = `${BASE_URL}/store/apps/details?${qs}`;

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -24,7 +24,7 @@ function similar (opts) {
     const qs = queryString.stringify({
       id: mergedOpts.appId,
       ...(mergedOpts.lang === -1 ? {} : { hl: mergedOpts.lang }),
-      ...(opts.country === -1 ? {} : { gl: mergedOpts.country })
+      ...(mergedOpts.country === -1 ? {} : { gl: mergedOpts.country })
     });
 
     const similarUrl = `${BASE_URL}/store/apps/details?${qs}`;

--- a/lib/similar.js
+++ b/lib/similar.js
@@ -23,8 +23,8 @@ function similar (opts) {
 
     const qs = queryString.stringify({
       id: mergedOpts.appId,
-      ...(mergedOpts.lang === -1 ? {} : {hl: mergedOpts.lang}),
-      ...(opts.country === -1 ? {} : {gl: mergedOpts.country}),
+      ...(mergedOpts.lang === -1 ? {} : { hl: mergedOpts.lang }),
+      ...(opts.country === -1 ? {} : { gl: mergedOpts.country })
     });
 
     const similarUrl = `${BASE_URL}/store/apps/details?${qs}`;


### PR DESCRIPTION
by passing -1 hl and gl are removed in request as requested in #404
I choosed -1 instead of undefined or false to be sure when argument is ommited nothing is changed.

fix the issue with forced 'hl':'en' for similar.
fix the issue where gl was missing in datasafety