### PR TITLE
Add "preregister" field to MAPPINGS

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -143,6 +143,10 @@ const MAPPINGS = {
     path: ['ds:9', 0],
     isArray: true,
     fun: helper.extractComments
+  },
+  preregister : {
+    path: ['ds:5', 1, 2, 18, 0],
+    fun: (val) => val === 1
   }
 };
 


### PR DESCRIPTION
As explained in[ this issue](https://github.com/facundoolano/google-play-scraper/issues/210), this PR fix the missing preregister property