### PR TITLE
Update `IReviewsResult` to have `data` attribute rather than `reviews`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -267,9 +267,9 @@ export interface IFnReviewsOptions extends IOptions {
 }
 
 
-export interface IReviewsResult{
-  reviews : IReviewsItem[]
-  nextPaginationToken? : string
+export interface IReviewsResult {
+  data: IReviewsItem[]
+  nextPaginationToken?: string
 }
 
 export interface IFnReviews {


### PR DESCRIPTION
## Issue

- TypeScript shows an error as `data` doesn't exist on the response of the review endpoint. The current types have `reviews` but the JS file uses `data` to supply the reviews array. Updated the TS types here to use `data` to match.

  ![Screen Shot 2024-02-14 at 10 39 41 AM](https://github.com/facundoolano/google-play-scraper/assets/19392291/fe0ca4a3-5427-4ae7-a9cc-8a19ddace890)

- It appears that the 10.0.0 version on NPM is out of date with the `main` branch. Can the latest be deployed? 