### PR TITLE
feat(permissions): add default country and update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ Returns the list of permissions an app has access to.
 
 * `appId`: the Google Play id of the application to get permissions for.
 * `lang` (optional, defaults to `'en'`): the two letter language code in which to fetch the permissions.
+* `country` (optional, defaults to `'us'`): the two letter country code in which to fetch the permissions.
 * `short` (optional, defaults to `false`): if `true`, the permission names will be returned instead of
 permission/description objects.
 

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -13,6 +13,7 @@ function permissions (opts) {
     }
 
     opts.lang = opts.lang || 'en';
+    opts.country = opts.country || 'us';
 
     processPermissions(opts)
       .then(resolve)
@@ -22,7 +23,7 @@ function permissions (opts) {
 
 function processPermissions (opts) {
   const body = `f.req=%5B%5B%5B%22xdSrCf%22%2C%22%5B%5Bnull%2C%5B%5C%22${opts.appId}%5C%22%2C7%5D%2C%5B%5D%5D%5D%22%2Cnull%2C%221%22%5D%5D%5D`;
-  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
+  const url = `${BASE_URL}/_/PlayStoreUi/data/batchexecute?rpcids=qnKhOb&f.sid=-697906427155521722&bl=boq_playuiserver_20190903.08_p0&hl=${opts.lang}&gl=${opts.country}&authuser&soc-app=121&soc-platform=1&soc-device=1&_reqid=1065213`;
 
   debug('batchexecute URL: %s', url);
   debug('with body: %s', body);


### PR DESCRIPTION
Fix the situation that permissions cannot be queried without a country code in some cases.
- Add default country ('us') if not provided in opts
- Update batchexecute URL to include country (gl) parameter
