### PR TITLE
fix typescript error.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -353,3 +353,5 @@ export const permissions: IFnPermissions
 export const categories: IFnCategories
 export const datasafety : IFnDataSafety
 export const memoized: IFnMemoized
+
+export default { app, list, search, developer, suggest, reviews, similar, permissions, categories, datasafety, memoized }


### PR DESCRIPTION
<img width="804" alt="Screenshot 2025-01-08 at 09 55 12" src="https://github.com/user-attachments/assets/2d5cb50b-e8ce-4734-b9b4-bede5ae6f109" />

when import from typescript project, there's a error that will cause tsc build fail (strict mode), add default export will fix this issue.