### PR TITLE
reviews sorting body structure fix

### DIFF
--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -80,7 +80,7 @@ function getBodyForRequests ({
 }) {
   /* The body is slight different for the initial and paginated requests */
   const formBody = {
-    [REQUEST_TYPE.initial]: `f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2Cnull%2C%5B2%2C${sort}%2C%5B${numberOfReviewsPerRequest}%2Cnull%2Cnull%5D%2Cnull%2C%5B%5D%5D%2C%5B%5C%22${appId}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`,
+    [REQUEST_TYPE.initial]: `f.req=[[["UsvDTd","[null,[2,${sort},[${numberOfReviewsPerRequest}],null,[null,null,null,null,null,null,null,null,2]],[\"${appId}\",7]]",null,"generic"]]]`,
     [REQUEST_TYPE.paginated]: `f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2Cnull%2C%5B2%2C${sort}%2C%5B${numberOfReviewsPerRequest}%2Cnull%2C%5C%22${withToken}%5C%22%5D%2Cnull%2C%5B%5D%5D%2C%5B%5C%22${appId}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`
   };
 

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -80,7 +80,7 @@ function getBodyForRequests ({
 }) {
   /* The body is slight different for the initial and paginated requests */
   const formBody = {
-    [REQUEST_TYPE.initial]: `f.req=[[["UsvDTd","[null,[2,${sort},[${numberOfReviewsPerRequest}],null,[null,null,null,null,null,null,null,null,2]],[\"${appId}\",7]]",null,"generic"]]]`,
+    [REQUEST_TYPE.initial]: `f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2C%5B2%2C${sort}%2C%5B${numberOfReviewsPerRequest}%5D%2Cnull%2C%5Bnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2Cnull%2C2%5D%5D%2C%5B%5C%22${appId}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`,
     [REQUEST_TYPE.paginated]: `f.req=%5B%5B%5B%22UsvDTd%22%2C%22%5Bnull%2Cnull%2C%5B2%2C${sort}%2C%5B${numberOfReviewsPerRequest}%2Cnull%2C%5C%22${withToken}%5C%22%5D%2Cnull%2C%5B%5D%5D%2C%5B%5C%22${appId}%5C%22%2C7%5D%5D%22%2Cnull%2C%22generic%22%5D%5D%5D`
   };
 


### PR DESCRIPTION
Key Changes:
The original payload was URL-encoded (%5B, %22, etc.), which made it harder to read and debug. I decoded it into a more readable JSON-like structure.

I adjusted the structure of the array inside the payload to match the expected format for the Google Play API. 
Specifically:

The sort and numberOfReviewsPerRequest variables are now correctly placed in the array.