### PR TITLE
fix: Improve input validation in extractCategories function

### DIFF
--- a/lib/utils/mappingHelpers.js
+++ b/lib/utils/mappingHelpers.js
@@ -107,7 +107,7 @@ function extractFeatures (featuresArray) {
  * @param {array} categories The categories array
  */
 function extractCategories (searchArray, categories = []) {
-  if (searchArray === null || searchArray.length === 0) return categories;
+  if (!Array.isArray(searchArray) || searchArray.length === 0) return categories;
 
   if (searchArray.length >= 4 && typeof searchArray[0] === 'string') {
     categories.push({


### PR DESCRIPTION
Sometimes search array is undefined and the scraping does not work. 