### PR TITLE
fix: Missing version, updated timestamp and recent changes

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -92,14 +92,17 @@ const MAPPINGS = {
   IAPRange: ['ds:5', 1, 2, 19, 0],
   androidVersion: {
     path: ['ds:5', 1, 2, 140, 1, 1, 0, 0, 1],
+    fallbackPath: ['ds:5', 1, 2, -1, '141', 1, 1, 0, 0, 1],
     fun: helper.normalizeAndroidVersion
   },
   androidVersionText: {
     path: ['ds:5', 1, 2, 140, 1, 1, 0, 0, 1],
+    fallbackPath: ['ds:5', 1, 2, -1, '141', 1, 1, 0, 0, 1],
     fun: (version) => version || 'Varies with device'
   },
   androidMaxVersion: {
     path: ['ds:5', 1, 2, 140, 1, 1, 0, 1, 1],
+    fallbackPath: ['ds:5', 1, 2, -1, '141', 1, 1, 0, 1, 1],
     fun: helper.normalizeAndroidVersion
   },
   developer: ['ds:5', 1, 2, 68, 0],
@@ -161,13 +164,19 @@ const MAPPINGS = {
   released: ['ds:5', 1, 2, 10, 0],
   updated: {
     path: ['ds:5', 1, 2, 145, 0, 1, 0],
+    fallbackPath: ['ds:5', 1, 2, -1, '146', 0, 1, 0],
     fun: (ts) => ts * 1000
   },
   version: {
     path: ['ds:5', 1, 2, 140, 0, 0, 0],
+    fallbackPath: ['ds:5', 1, 2, -1, '141', 0, 0, 0],
     fun: (val) => val || 'VARY'
   },
-  recentChanges: ['ds:5', 1, 2, 144, 1, 1],
+  recentChanges: {
+    path: ['ds:5', 1, 2, 144, 1, 1],
+    fallbackPath: ['ds:5', 1, 2, -1, '145', 1, 1],
+    fun: (val) => val
+  },
   comments: {
     path: [],
     isArray: true,

--- a/lib/utils/scriptData.js
+++ b/lib/utils/scriptData.js
@@ -45,9 +45,15 @@ function extractor (mappings) {
       // extractDataWithServiceRequestId explanation:
       // https://github.com/facundoolano/google-play-scraper/pull/412
       // assume spec object
-      const input = (spec.useServiceRequestId)
-        ? extractDataWithServiceRequestId(parsedData, spec)
-        : R.path(spec.path, parsedData);
+      let input;
+      if (spec.useServiceRequestId) {
+        input = extractDataWithServiceRequestId(parsedData, spec);
+      } else {
+        input = R.path(spec.path, parsedData);
+        if ((input === null || input === undefined) && spec.fallbackPath) {
+          input = R.path(spec.fallbackPath, parsedData);
+        }
+      }
 
       return spec.fun(input, parsedData);
     }, mappings);


### PR DESCRIPTION
Google Play has introduced a new data structure variant that affects metadata fields with indexes greater than 100 (as tested, for now) in the `ds:5[1][2]` array. The array may sometimes contain an object at the last index instead of individual indexed elements. This object contains the metadata with keys corresponding to the original index, plus one. (e.g., index 140 becomes key `'141'`). 

Fixes #725 by
1. Modifying the extractor to use the `fallbackPath` if provided when the primary path returns null or undefined
2. Adding `fallbackPath` for affected fields using `['ds:5', 1, 2, -1, '<index+1>', ...]` notation