### PR TITLE
docs: clarify review title is always null (closes #710)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ Retrieves a page of reviews for a specific application.
 
 Note that this method returns reviews in a specific language (english by default), so you need to try different languages to get more reviews. Also, the counter displayed in the Google Play page refers to the total number of 1-5 stars ratings the application has, not the written reviews count. So if the app has 100k ratings, don't expect to get 100k reviews by using this method.
 
+The `title` field is always `null`. Google Play removed review titles from the public response some time ago; the field is kept in the result for backwards compatibility but no longer carries any value.
+
 You can get all reviews at once, by sending the `num` parameter (i.g. 5000), or paginated reviews (with 150 per page), by setting the `pagination` parameter to true;
 
 You`ll have to choose wich method is better for your use case.
@@ -355,8 +357,8 @@ Results:
       date: '2013-11-10T18:31:42.174Z',
       score: 5,
       scoreText: '5',
-      url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRWZaVHVZZ081NlNsRW9TV0hJeklGSTBvYTBTUlFQUUJIZThBSGJDX2s1Y1o0ZXRCbUtLZmgzTE1PMUttRmpRSS1YcFgxRmx1ZXNtVzlVS0Zz'
-      title: 'I LOVE IT',
+      url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRWZaVHVZZ081NlNsRW9TV0hJeklGSTBvYTBTUlFQUUJIZThBSGJDX2s1Y1o0ZXRCbUtLZmgzTE1PMUttRmpRSS1YcFgxRmx1ZXNtVzlVS0Zz',
+      title: null,
       text: 'It has skins and snowballs everything I wanted its so cool I love it!!!!!!!!',
       replyDate: '2013-11-10T18:31:42.174Z',
       replyText: 'thanks for playing Panda vs Zombies!',
@@ -385,7 +387,7 @@ Results:
       url: 'https://play.google.com/store/apps/details?id=com.dxco.pandavszombies&reviewId=Z3A6QU9xcFRPRmFHdlBFS2pGS2JVYW5Dd3kxTm1qUzRxQlYyc3Z4ZE9CYXRuc0hkclV3a09hbEFkOVdoWmw3eFN5VjF4cDJPLTg5TW5ZUjl1Zm9HOWc5NGtr',
       score: 5,
       scoreText: '5',
-      title: 'CAN NEVER WAIT TILL NEW UPDATE',
+      title: null,
       text: 'Love it but needs to pay more attention to pocket edition',
       replyDate: null,
       replyText: null,

--- a/index.d.ts
+++ b/index.d.ts
@@ -165,11 +165,12 @@ export interface IReviewsItem {
   score: number
   scoreText: string
   url: string
-  title: string
+  /** Always `null` — Google Play stopped surfacing review titles. */
+  title: null
   text: string
-  replyDate: string
-  replyText: string
-  version: string
+  replyDate: string | null
+  replyText: string | null
+  version: string | null
   thumbsUp: number
   criterias: Array<{
     criteria: string

--- a/lib/reviews.js
+++ b/lib/reviews.js
@@ -199,6 +199,9 @@ function getReviewsMappings (appId) {
       path: [0],
       fun: (reviewId) => `${BASE_URL}/store/apps/details?id=${appId}&reviewId=${reviewId}`
     },
+    // Google Play removed review titles from the public review payload; the
+    // field is kept in the response shape for backwards compatibility but is
+    // always null. See #710.
     title: {
       path: [0],
       fun: () => null


### PR DESCRIPTION
Closes #710.

## Background

`getReviewsMappings` in `lib/reviews.js` already hard-codes `title: { path: [0], fun: () => null }` because Google Play removed review titles from the public response some time ago. Behavior is intentional — but `index.d.ts` types `title` as `string`, the README example shows `title: 'I LOVE IT'`, and nothing documents the removal, so users keep filing the same surprise (#710 is the most recent of several).

## Changes

- `lib/reviews.js`: one-line inline comment over the always-null mapping explaining why and pointing at #710 so the next time someone wonders, the code answers them.
- `index.d.ts`: tighten `IReviewsItem.title` from `string` to `null`. Also tightens `replyDate`, `replyText`, `version` to `string | null` — the runtime mapping already falls these back to `null` (lines 207–217 in `lib/reviews.js`), but the type was claiming they're always `string`.
- `README.md`:
  - One-line note under the `reviews()` section: `title` is always `null`, kept for backwards compatibility.
  - Replace the two `title: 'I LOVE IT' / 'CAN NEVER WAIT TILL NEW UPDATE'` strings in the example payload with `title: null`, matching reality. Also fixes a missing trailing comma in the first example object.

No behavior change. Existing tests (`test/lib.reviews.js`) already assert `review.title` is null via `assertValid()` at line 15, so the runtime contract is locked in — this PR just makes the docs and types match.

## Test plan

- `npm run lint` — clean
- `npx mocha test/lib.reviews.js` — 8/8 pass

## Disclosure

Drafted with assistance from Claude (Anthropic). I read every line, ran lint + tests, and verified the always-null behavior by inspecting the existing mapping + tests. Happy to revise per any maintainer preference (e.g. drop the type tightening on `replyDate`/`replyText`/`version` if you'd rather keep this PR scoped strictly to `title`).