### PR TITLE
docs: explain VARY / 'Varies with device' return values (closes #727)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Results:
   adSupported: false,
   released: undefined,
   updated: 1576868577000,
-  version: 'Varies with device',
+  version: 'VARY',
   recentChanges: 'Improved offline translations with upgraded language downloads',
   comments: [],
   preregister: false,
@@ -121,6 +121,13 @@ Results:
   isAvailableInPlayPass: false
 }
 ```
+
+When the Play Store reports "Varies with device" (typically for apps published as Android App Bundles), the version-related fields fall back to sentinel strings rather than `null`:
+
+* `version`, `androidVersion`, `androidMaxVersion` return the literal string `'VARY'`.
+* `androidVersionText` returns the literal string `'Varies with device'`.
+
+The Play Store web page does not expose a concrete version in this case, so the scraper cannot recover one. To get the device-specific version your users would actually install, query the Play Store Android client (or the unofficial `/_/PlayStoreUi/data/batchexecute` endpoint) with a Play-Services device-spec payload — that path is out of scope for this library.
 
 ### list
 Retrieve a list of applications from one of the collections at Google Play. Options:

--- a/lib/app.js
+++ b/lib/app.js
@@ -90,6 +90,9 @@ const MAPPINGS = {
     fun: Boolean
   },
   IAPRange: ['ds:5', 1, 2, 19, 0],
+  // When the Play Store reports "Varies with device" (typical for App Bundles),
+  // androidVersion/androidMaxVersion fall back to the literal string 'VARY' and
+  // androidVersionText falls back to 'Varies with device'. See README + #727.
   androidVersion: {
     path: ['ds:5', 1, 2, 140, 1, 1, 0, 0, 1],
     fallbackPath: ['ds:5', 1, 2, -1, '141', 1, 1, 0, 0, 1],


### PR DESCRIPTION
Closes #727.

## Background

When the Play Store reports "Varies with device" — typical for apps published as Android App Bundles such as WhatsApp, Facebook, Instagram — the scraper substitutes sentinel strings rather than returning `null`. The behavior is intentional and ships in tests (`test/lib.app.js` asserts `app.androidMaxVersion === 'VARY'` at line 38 and `app.androidVersion === 'VARY'` at line 127), but it isn't called out anywhere in user-facing docs, so users keep filing the same surprise (#727).

The README is also subtly wrong: the `app()` example payload claims `version: 'Varies with device'`, but the actual runtime returns the literal string `'VARY'` for the `version` field — only `androidVersionText` falls back to `'Varies with device'`. Confirmed by querying `com.whatsapp` on `10.1.2`:

```
version: "VARY"
androidVersion: "VARY"
androidVersionText: "Varies with device"
androidMaxVersion: "VARY"
```

## Changes

- `README.md`:
  - New paragraph under the `app()` Results block enumerating the four fields and which sentinel each one falls back to.
  - Corrects the example payload `version: 'Varies with device'` → `version: 'VARY'` to match what the lib actually returns.
- `lib/app.js`: brief in-source comment over the `androidVersion` / `androidVersionText` / `androidMaxVersion` mapping group pointing at the README and #727.

No behavior change. The sentinel-string convention is preserved exactly as-is; changing it would be a breaking change for every consumer that already special-cases `'VARY'`, and is something the maintainer should weigh, not a docs PR.

## Test plan

- `npm run lint` — clean
- `npx mocha test/lib.app.js` — same 79 pass / 2 fail as `main` (the two failures are stale-data assertions: a German developer moved offices, and the INR price now includes a comma thousand-separator). My diff touches neither.

## Disclosure

Drafted with assistance from Claude (Anthropic). I verified the runtime behavior against `com.whatsapp` on `main` before/after, ran lint, and ran the full app test suite. Happy to revise.